### PR TITLE
update poc docker-registry-unauth.yml

### DIFF
--- a/pocs/docker-registry-unauth.yml
+++ b/pocs/docker-registry-unauth.yml
@@ -1,0 +1,18 @@
+name: poc-yaml-docker-registry-api-unauth
+rules:
+  - method: GET
+    path: /v2/
+    follow_redirects: false
+    expression: >
+      status==200 &&
+      headers['docker-distribution-api-version'].contains('registry/2.0')
+  - method: GET
+    path: /v2/_catalog
+    follow_redirects: false
+    expression: >
+      status==200 && content_type.contains('application/json') &&
+      body.bcontains(b'repositories')
+detail:
+  author: p0wd3r
+  links:
+    - http://www.polaris-lab.com/index.php/archives/253/


### PR DESCRIPTION
## 本 poc 是干什么的

Docker registry API 未授权访问漏洞

## 测试环境

无

## 备注

参考文档：http://www.polaris-lab.com/index.php/archives/253/