### PR TITLE
add MOVE enum

### DIFF
--- a/tests/schema.json
+++ b/tests/schema.json
@@ -29,7 +29,8 @@
               "OPTIONS",
               "HEAD",
               "PUT",
-              "CONNECT"
+              "CONNECT",
+              "MOVE"
             ]
           },
           "path": {


### PR DESCRIPTION
由于增加的poc-yaml-activemq-CVE-2016-3088.yml 需要MOVE方法，默认test工程里面没有MOVE方法，造成每次检测都失败，随添加HTTP MOVE方法。

