### PR TITLE
add jboss-unauth poc

### DIFF
--- a/pocs/jboss-unauth.yml
+++ b/pocs/jboss-unauth.yml
@@ -1,0 +1,11 @@
+name: poc-yaml-jboss-unauth
+rules:
+  - method: GET
+    path: /jmx-console/
+    follow_redirects: false
+    expression: |
+      status == 200 && body.bcontains(b'jboss.management.local') && body.bcontains(b'jboss.web')
+detail:
+  author: FiveAourThe(https://github.com/FiveAourThe)
+  links:
+    - https://xz.aliyun.com/t/6103


### PR DESCRIPTION
add jboss-unauth poc
## 本 poc 是检测什么漏洞的
检测Jboss未授权访问漏洞的PoC
## 测试环境
测试环境使用的时Docker环境，地址为：https://hub.docker.com/r/testjboss/jboss
## 备注
第一次写PoC，多谢解答疑难！