### PR TITLE
add couchdb-unauth.yml

### DIFF
--- a/pocs/couchdb-unauth.yml
+++ b/pocs/couchdb-unauth.yml
@@ -1,0 +1,13 @@
+name: poc-yaml-couchdb-unauth
+rules:
+  - method: GET
+    path: /_config
+    follow_redirects: false
+    expression: >
+      status == 200 && body.bcontains(b'httpd_design_handlers') &&
+      body.bcontains(b'external_manager') &&
+      body.bcontains(b'replicator_manager')
+detail:
+  author: FiveAourThe(https://github.com/FiveAourThe)
+  links:
+    - https://www.seebug.org/vuldb/ssvid-91597


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
该PoC是检测CouchDB未授权访问漏洞的，该漏洞可以导致任意命令执行。

## 测试环境
使用的靶场环境是Vulhub的测试环境：https://github.com/vulhub/vulhub/tree/master/couchdb/CVE-2017-12636。

## 备注
第二次提交PoC啦！本地测试已通过。