### PR TITLE
add kibana-unauth.yml

### DIFF
--- a/pocs/kibana-unauth.yml
+++ b/pocs/kibana-unauth.yml
@@ -1,5 +1,5 @@
 name: poc-yaml-kibana-unauth
-rules: 
+rules:
   - method: GET
     path: /app/kibana
     follow_redirects: false

--- a/pocs/kibana-unauth.yml
+++ b/pocs/kibana-unauth.yml
@@ -1,0 +1,11 @@
+name: poc-yaml-kibana-unauth
+rules: 
+  - method: GET
+    path: "/app/kibana"
+    follow_redirects: false
+    expression: |
+      status == 200 && body.bcontains(b'.kibanaWelcomeView')
+detail:
+  author: Isaac(https://github.com/IsaacQiang)
+  links:
+    - https://zhuanlan.zhihu.com/p/61215662

--- a/pocs/kibana-unauth.yml
+++ b/pocs/kibana-unauth.yml
@@ -1,7 +1,7 @@
 name: poc-yaml-kibana-unauth
 rules: 
   - method: GET
-    path: "/app/kibana"
+    path: /app/kibana
     follow_redirects: false
     expression: |
       status == 200 && body.bcontains(b'.kibanaWelcomeView')


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的

检测Kibana未授权访问漏洞的PoC

## 测试环境

使用官方 镜像即可 docker pull kibana
docker run --name leon_kibana -p 5601:5601 -d -e ELASTICSEARCH_URL=http://192.168.9.151:9200 kibana

## 备注

默认kibana没有权限认证 需要使用xpack插件 目前外网搜索引擎可以发现很多未授权访问问题，与ES同属一类问题

<img width="732" alt="WX20191023-180218@2x" src="https://user-images.githubusercontent.com/16198362/67382069-790d8a80-f5bf-11e9-839d-3b213084647e.png">
