### PR TITLE
Create jira-unauthorized-cve-2019-11581.yml

### DIFF
--- a/pocs/jira-unauthorized-cve-2019-11581.yml
+++ b/pocs/jira-unauthorized-cve-2019-11581.yml
@@ -1,0 +1,12 @@
+name: poc-yaml-cve-2019-11581
+rules:
+  - method: GET
+    path: /secure/ContactAdministrators!default.jspa
+    follow_redirects: true
+    expression: |
+      response.status == 200 && response.body.bcontains(b'contact-administrators-subject')
+detail:
+  author: harris2015(https://github.com/harris2015)
+  Affected Version: "cve-2019-11581"
+  links:
+    - https://confluence.atlassian.com/jira/jira-security-advisory-2019-07-10-973486595.html


### PR DESCRIPTION
----------

## 本 poc 是检测什么漏洞的
Atlassian Jira是澳大利亚Atlassian公司的一套缺陷跟踪管理系统。该系统主要用于对工作中各类问题、缺陷进行跟踪管理。

Atlassian Jira Server和Jira Data Center存在服务端模板注入漏洞，成功利用此漏洞的攻击者可对运行受影响版本的Jira Server或Jira Data Center的服务器执行任意命令，从而获取服务器权限，严重危害网络资产。

cve编号：cve-2019-11581

## 测试环境
网上的 请私聊

测试截图:
![Image text](https://raw.githubusercontent.com/harris2015/xray/master/tests/QQ%E6%88%AA%E5%9B%BE20191122150729.png)
## 备注
https://confluence.atlassian.com/jira/jira-security-advisory-2019-07-10-973486595.html