### PR TITLE
phpstudy-nginx-wrong-resolve

### DIFF
--- a/pocs/phpstudy-nginx-wrong-resolve-2.yml
+++ b/pocs/phpstudy-nginx-wrong-resolve-2.yml
@@ -12,13 +12,13 @@ rules:
     path: /index.php
     follow_redirects: false
     expression: |
-      response.status == 200 && response.headers['Server'].contains('nginx')
+      response.status == 200 && response.headers["Server"].contains("nginx")
 
   - method: GET
     path: /index.php/.php
     follow_redirects: false
     expression: |
-      response.status == 200 && response.headers['Server'].contains('nginx')
+      response.status == 200 && response.headers["Server"].contains("nginx")
 detail:
   author: LoRexxar(https://lorexxar.cn)
   links:

--- a/pocs/phpstudy-nginx-wrong-resolve-2.yml
+++ b/pocs/phpstudy-nginx-wrong-resolve-2.yml
@@ -1,4 +1,4 @@
-name: poc-yaml-phpstudy-nginx-wrong-resolve # nolint[:namematch]
+name: poc-yaml-phpstudy-nginx-wrong-resolve  # nolint[:namematch]
 set:
   name: randomInt(10000000, 99999999)
 rules:

--- a/pocs/phpstudy-nginx-wrong-resolve-2.yml
+++ b/pocs/phpstudy-nginx-wrong-resolve-2.yml
@@ -1,0 +1,17 @@
+name: poc-yaml-phpstudy-nginx-wrong-resolve
+rules:
+  - method: GET
+    path: /index.php
+    follow_redirects: false
+    expression: |
+      response.status == 200
+
+  - method: GET
+    path: /index.php/.php
+    follow_redirects: false
+    expression: |
+      response.status == 200
+detail:
+  author: LoRexxar(https://lorexxar.cn)
+  links:
+    - https://www.seebug.org/vuldb/ssvid-98364

--- a/pocs/phpstudy-nginx-wrong-resolve-2.yml
+++ b/pocs/phpstudy-nginx-wrong-resolve-2.yml
@@ -7,13 +7,11 @@ rules:
     follow_redirects: false
     expression: |
       response.status != 200
-
   - method: GET
     path: /index.php
     follow_redirects: false
     expression: |
       response.status == 200
-
   - method: GET
     path: /index.php/.php
     follow_redirects: false

--- a/pocs/phpstudy-nginx-wrong-resolve-2.yml
+++ b/pocs/phpstudy-nginx-wrong-resolve-2.yml
@@ -7,16 +7,18 @@ rules:
     follow_redirects: false
     expression: |
       response.status != 200
+
   - method: GET
     path: /index.php
     follow_redirects: false
     expression: |
-      response.status == 200
+      response.status == 200 && response.headers['Server'].contains('nginx')
+
   - method: GET
     path: /index.php/.php
     follow_redirects: false
     expression: |
-      response.status == 200
+      response.status == 200 && response.headers['Server'].contains('nginx')
 detail:
   author: LoRexxar(https://lorexxar.cn)
   links:

--- a/pocs/phpstudy-nginx-wrong-resolve-2.yml
+++ b/pocs/phpstudy-nginx-wrong-resolve-2.yml
@@ -1,5 +1,13 @@
-name: poc-yaml-phpstudy-nginx-wrong-resolve
+name: poc-yaml-phpstudy-nginx-wrong-resolve # nolint[:namematch]
+set:
+  name: randomInt(10000000, 99999999)
 rules:
+  - method: GET
+    path: /{{name}}.php
+    follow_redirects: false
+    expression: |
+      response.status != 200
+
   - method: GET
     path: /index.php
     follow_redirects: false

--- a/pocs/phpstudy-nginx-wrong-resolve.yml
+++ b/pocs/phpstudy-nginx-wrong-resolve.yml
@@ -12,13 +12,13 @@ rules:
     path: /index.html
     follow_redirects: false
     expression: |
-      response.status == 200 && response.headers['Server'].contains('nginx')
+      response.status == 200 && response.headers["Server"].contains("nginx")
 
   - method: GET
     path: /index.html/.php
     follow_redirects: false
     expression: |
-      response.status == 200 && response.headers['Server'].contains('nginx')
+      response.status == 200 && response.headers["Server"].contains("nginx")
 detail:
   author: LoRexxar(https://lorexxar.cn)
   links:

--- a/pocs/phpstudy-nginx-wrong-resolve.yml
+++ b/pocs/phpstudy-nginx-wrong-resolve.yml
@@ -7,13 +7,11 @@ rules:
     follow_redirects: false
     expression: |
       response.status != 200
-
   - method: GET
     path: /index.html
     follow_redirects: false
     expression: |
       response.status == 200
-
   - method: GET
     path: /index.html/.php
     follow_redirects: false

--- a/pocs/phpstudy-nginx-wrong-resolve.yml
+++ b/pocs/phpstudy-nginx-wrong-resolve.yml
@@ -7,7 +7,7 @@ rules:
     follow_redirects: false
     expression: |
       response.status != 200
-      
+
   - method: GET
     path: /index.html
     follow_redirects: false

--- a/pocs/phpstudy-nginx-wrong-resolve.yml
+++ b/pocs/phpstudy-nginx-wrong-resolve.yml
@@ -7,16 +7,18 @@ rules:
     follow_redirects: false
     expression: |
       response.status != 200
+      
   - method: GET
     path: /index.html
     follow_redirects: false
     expression: |
-      response.status == 200
+      response.status == 200 && response.headers['Server'].contains('nginx')
+
   - method: GET
     path: /index.html/.php
     follow_redirects: false
     expression: |
-      response.status == 200
+      response.status == 200 && response.headers['Server'].contains('nginx')
 detail:
   author: LoRexxar(https://lorexxar.cn)
   links:

--- a/pocs/phpstudy-nginx-wrong-resolve.yml
+++ b/pocs/phpstudy-nginx-wrong-resolve.yml
@@ -1,0 +1,17 @@
+name: poc-yaml-phpstudy-nginx-wrong-resolve
+rules:
+  - method: GET
+    path: /index.html
+    follow_redirects: false
+    expression: |
+      response.status == 200
+
+  - method: GET
+    path: /index.html/.php
+    follow_redirects: false
+    expression: |
+      response.status == 200
+detail:
+  author: LoRexxar(https://lorexxar.cn)
+  links:
+    - https://www.seebug.org/vuldb/ssvid-98364

--- a/pocs/phpstudy-nginx-wrong-resolve.yml
+++ b/pocs/phpstudy-nginx-wrong-resolve.yml
@@ -1,5 +1,13 @@
 name: poc-yaml-phpstudy-nginx-wrong-resolve
+set:
+  name: randomInt(10000000, 99999999)
 rules:
+  - method: GET
+    path: /{{name}}.php
+    follow_redirects: false
+    expression: |
+      response.status != 200
+
   - method: GET
     path: /index.html
     follow_redirects: false


### PR DESCRIPTION
##  本 poc 是检测什么漏洞的

phpstudy 的nginx解析漏洞，可以解析任意文件为php。

详情见: [https://www.seebug.org/vuldb/ssvid-98364](https://www.seebug.org/vuldb/ssvid-98364)

## 测试环境

http://61.184.150.250:81/index.html

## 备注

漏洞版本为nginx版本1.15.11的phpstudy，还挺有趣的