### PR TITLE
解决nginx解析漏洞误报高的问题

### DIFF
--- a/pocs/phpstudy-nginx-wrong-resolve-2.yml
+++ b/pocs/phpstudy-nginx-wrong-resolve-2.yml
@@ -19,6 +19,12 @@ rules:
     follow_redirects: false
     expression: |
       response.status == 200 && response.headers["Server"].contains("nginx")
+
+  - method: GET
+    path: /index.php/.xxx
+    follow_redirects: false
+    expression: |
+      response.status == 404
 detail:
   author: LoRexxar(https://lorexxar.cn)
   links:

--- a/pocs/phpstudy-nginx-wrong-resolve-2.yml
+++ b/pocs/phpstudy-nginx-wrong-resolve-2.yml
@@ -24,7 +24,7 @@ rules:
     path: /index.php/.xxx
     follow_redirects: false
     expression: |
-      response.status == 404
+      response.status != 200
 detail:
   author: LoRexxar(https://lorexxar.cn),0h1in9e(https://www.ohlinge.cn)
   links:

--- a/pocs/phpstudy-nginx-wrong-resolve-2.yml
+++ b/pocs/phpstudy-nginx-wrong-resolve-2.yml
@@ -26,6 +26,6 @@ rules:
     expression: |
       response.status == 404
 detail:
-  author: LoRexxar(https://lorexxar.cn)
+  author: LoRexxar(https://lorexxar.cn),0h1in9e(https://www.ohlinge.cn)
   links:
     - https://www.seebug.org/vuldb/ssvid-98364

--- a/pocs/phpstudy-nginx-wrong-resolve.yml
+++ b/pocs/phpstudy-nginx-wrong-resolve.yml
@@ -24,8 +24,8 @@ rules:
     path: /index.html/.xxx
     follow_redirects: false
     expression: |
-      response.status == 404
+      response.status != 200
 detail:
-  author: LoRexxar(https://lorexxar.cn)
+  author: LoRexxar(https://lorexxar.cn),0h1in9e(https://www.ohlinge.cn)
   links:
     - https://www.seebug.org/vuldb/ssvid-98364

--- a/pocs/phpstudy-nginx-wrong-resolve.yml
+++ b/pocs/phpstudy-nginx-wrong-resolve.yml
@@ -19,6 +19,12 @@ rules:
     follow_redirects: false
     expression: |
       response.status == 200 && response.headers["Server"].contains("nginx")
+
+  - method: GET
+    path: /index.html/.xxx
+    follow_redirects: false
+    expression: |
+      response.status == 404
 detail:
   author: LoRexxar(https://lorexxar.cn)
   links:


### PR DESCRIPTION
**请先认真阅读下列要求，如不符合会被直接关闭 PR**

- 确保当前 POC 与已有的 POC 没有重复，除了仓库 `pocs` 目录中的，还有内置的几个用 Go 写的 POC也不要重复：
  ```
  poc-go-php-cve-2019-11043-rce
  poc-go-seeyon-htmlofficeservlet-rce
  poc-go-tongda-lfi-upload-rce
  poc-go-tongda-arbitrary-auth
  poc-go-ecology-dbconfig-info-leak
  poc-go-tomcat-put
  poc-go-tomcat-cve-2020-1938
  ```
  
- 阅读规范和要求 
  - https://chaitin.github.io/xray/#/guide/contribute
  - https://chaitin.github.io/xray/#/guide/high_quality_poc

- 一个 pull request 只提交一个 poc

- 对于 0day / 1 day 等未大面积公开细节的漏洞请勿提交，可以私聊群管理员

 - 不接受没有测试环境的 poc，测试环境可以使用 [vulhub](https://github.com/vulhub/vulhub/) 或 [vulnapps](https://github.com/Medicean/VulApps)，也可以提供 fofa/zoomeye/shodan 等搜索关键字。 请勿直接填写公网上未修复的站点的地址，如果有特殊情况，请私聊群内管理解决。
 
- 如果你的 poc 被合并或者没有合并但是评论说需要发送奖励，请查看 https://chaitin.github.io/xray/#/guide/feedback 并添加最下面的微信，说明你的 poc 地址，方便发送奖励。

**我是分割线，在提交 poc 填写说明的时候，请务必阅读上方要求，然后删除本分割线和上方的内容，只保留下面自定义的部分即可，否则不予通过。**

----------

## 本 poc 是检测什么漏洞的
nginx解析漏洞poc修复

## 测试环境
在原有
/index.php/.php 200ok的基础上添加/index.php/.xxx 404，二者结合可解决nginx解析漏洞误报问题


例如如下环境按照原来poc会误报为漏洞：
https://edisk.cloud.baidu.com/index.php/.php 200ok
https://edisk.cloud.baidu.com/index.php/.xxx 200ok

https://edisk.cloud.baidu.com/frontend/runtime.cac3f3c623931a0fa317.js/1.php   404
## 备注
