### PR TITLE
wordpress wp-file-manager插件远程代码执行漏洞（CVE-2020-25213）

### DIFF
--- a/pocs/wordpress-plugin-file-manager-rce
+++ b/pocs/wordpress-plugin-file-manager-rce
@@ -1,0 +1,10 @@
+name: poc-yaml-wordpress-plugin-file-manager-rce
+rules:
+  - method: GET
+    path: /wp-content/plugins/wp-file-manager/lib/php/connector.minimal.php
+    follow_redirects: true
+    expression: response.body.bcontains(bytes("errUnknownCmd"))
+detail:
+  author: dkerror
+  links:
+    - https://www.seebug.org/vuldb/ssvid-99077


### PR DESCRIPTION
name: poc-yaml-wordpress-plugin-file-manager-rce
rules:
  - method: GET
    path: /wp-content/plugins/wp-file-manager/lib/php/connector.minimal.php
    follow_redirects: true
    expression: response.body.bcontains(bytes("errUnknownCmd"))
detail:
  author: dkerror
  links:
    - https://www.seebug.org/vuldb/ssvid-99077

----------

## 本 poc 是检测什么漏洞的

检测 wordpress wp-file-manager插件远程代码执行漏洞（CVE-2020-25213）

## 测试环境

WordPress 5.6.2

靶场测试地址: http://149.129.86.154:8899/

## 备注
