### PR TITLE
ruijie-uac-cnvd-2021-14536

### DIFF
--- a/pocs/ruijie-uac-cnvd-2021-14536.yml
+++ b/pocs/ruijie-uac-cnvd-2021-14536.yml
@@ -4,7 +4,7 @@ rules:
     path: /login.php
     follow_redirects: false
     expression: |
-      response.status == 200 && response.body.bcontains(b"<title>RG-UAC登录页面</title>") && response.body.bcontains(b"get_dkey_passwd") && response.body.bcontains(b"password")
+      response.status == 200 && response.body.bcontains(b"<title>RG-UAC登录页面</title>") && response.body.bcontains(b"get_dkey_passwd") && "\"password\":\"[a-f0-9]{32}\"".bmatches(response.body)
 detail:
   author: jweny(https://github.com/jweny)
   links:

--- a/pocs/ruijie-uac-cnvd-2021-14536.yml
+++ b/pocs/ruijie-uac-cnvd-2021-14536.yml
@@ -1,0 +1,11 @@
+name: poc-yaml-ruijie-uac-cnvd-2021-14536
+rules:
+  - method: GET
+    path: /login.php
+    follow_redirects: false
+    expression: |
+      response.status == 200 && response.body.bcontains(b"<title>RG-UAC登录页面</title>") && response.body.bcontains(b"get_dkey_passwd") && response.body.bcontains(b"password")
+detail:
+  author: jweny(https://github.com/jweny)
+  links:
+    - https://mp.weixin.qq.com/s?__biz=Mzg3NDU2MTg0Ng==&mid=2247483972&idx=1&sn=b51678c6206a533330b0279454335065


### PR DESCRIPTION
此pr为我之前提交的 https://github.com/chaitin/xray/pull/1123/files 的修复版本

本 poc 是检测什么漏洞的
锐捷RG-UAC CNVD-2021-14536 信息泄露漏洞
账号密码泄露

测试环境
Quake空间测绘搜索语句：title:"RG-UAC登录页面" AND response:"admin"

备注

-- 增加MD5正则判断。修复后的版本不会产生误报。