### PR TITLE
modify webmin-cve-2019-15107-rce.yml

### DIFF
--- a/pocs/webmin-cve-2019-15107-rce.yml
+++ b/pocs/webmin-cve-2019-15107-rce.yml
@@ -2,6 +2,7 @@ name: poc-yaml-webmin-cve-2019-15107-rce
 set:
   r1: randomInt(800000000, 1000000000)
   r2: randomInt(800000000, 1000000000)
+  url: request.url
 rules:
   - method: POST
     path: /password_change.cgi


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
修正webmin-cve-2019-15107-rce.yml，该PoC的url变量未定义，但是却在Referer中使用。
CVE-2019-15107的验证会用到Referer，不然该PoC无效
## 测试环境
https://github.com/vulhub/vulhub/tree/master/webmin/CVE-2019-15107
## 备注
