### PR TITLE
Create apache-cve-2021-41773.yml

### DIFF
--- a/pocs/apache-httpd-cve-2021-41773-path-traversal.yml
+++ b/pocs/apache-httpd-cve-2021-41773-path-traversal.yml
@@ -1,4 +1,4 @@
-name: poc-yaml-apache-cve-2021-41773
+name: poc-yaml-apache-httpd-cve-2021-41773-path-traversal
 groups:
   cgibin:
     - method: GET


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
Apache HTTP Server路径穿越漏洞 (CVE-2021-41773)
## 测试环境
https://github.com/vulhub/vulhub/blob/master/httpd/CVE-2021-41773/README.zh-cn.md
## 备注
