### PR TITLE
检测cve-2021-3129

### DIFF
--- a/pocs/laravel-cve-2021-3129.yml
+++ b/pocs/laravel-cve-2021-3129.yml
@@ -20,7 +20,8 @@ rules:
                 }
         }
       follow_redirects: true
-    expression: response.body.bcontains(bytes(r))
+    expression: >
+      response.status == 500 && response.body.bcontains(bytes("file_get_contents(" + string(r) + ")")) && response.body.bcontains(bytes("failed to open stream"))
 expression: r0()
 detail:
   author: Jarcis-cy(https://github.com/Jarcis-cy)


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
检测cve-2021-3129，Laravel使用了Ignition提供的错误页面，攻击者可以通过phar://协议来执行反序列化操作，进而执行任意代码
## 测试环境
https://github.com/vulhub/vulhub/tree/master/laravel/CVE-2021-3129