### PR TITLE
Fix Python3 Flask bug: ImportError: cannot import name 'escape' from …

### DIFF
--- a/webhook/requirements.txt
+++ b/webhook/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.1.1
+Flask==2.1.0
 requests==2.22.0
 pyyaml==5.1.2
 cached-property==1.5.1


### PR DESCRIPTION
…'jinja2' (/usr/local/lib/python3.9/dist-packages/jinja2/__init__.py)

Signed-off-by: DroidKali <DroidKali@users.noreply.github.com>

----------

## 本 poc 是检测什么漏洞的
修复webhook中app.py中一个Flask的依赖bug
```bash
webhook git:(master) python3 app.py                      Traceback (most recent call last):
  File "/root/XRAY/webhook/app.py", line 3, in <module>
    from flask import Flask, request, redirect
  File "/usr/local/lib/python3.9/dist-packages/flask/__init__.py", line 14, in <module>
    from jinja2 import escape
ImportError: cannot import name 'escape' from 'jinja2' (/usr/local/lib/python3.9/dist-packages/jinja2/__init__.py)
```

## 测试环境
Kali Linux 2022.1 
Python3.9.7

## 备注
